### PR TITLE
Doc org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cfbfastR
 Title: Functions to Access College Football Play by Play Data
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: 
     c(person(given = "Saiem",
              family = "Gilani",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 # cfbfastR 
 
-### **v1.2.0**
+### **v1.2.1**
+##### **Minor release**
+
+* Added headshot_url to outputs of [```cfbd_team_rosters```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_teams.html)
+
+* Renamed returns in [```cfbd_game_advanced()```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_games.html):
+  - `rushing_line_yd_avg` to plural `rushing_line_yds_avg`
+  - `rushing_second_lvl_yd_avg` to plural `rushing_second_lvl_yds_avg`
+  - `rushing_open_field_yd_avg` to plural `rushing_open_field_yds_avg`
+
+* Completed documentation for all returns except ```cfbd_pbp_data()```
+
+* Continued work on intro vignette
+
+### **v1.2.0-1**
 #### **Add significant documentation to the package**
 
 * Added mini-vignettes pertaining to CFB Data functionality:   

--- a/R/cfbd_games.R
+++ b/R/cfbd_games.R
@@ -1,15 +1,15 @@
 #' @name cfbd_games
 #' @aliases cfbd_games cfbd_game_info cfbd_calendar cfbd_game_media cfbd_game_box_advanced cfbd_game_player_stats cfbd_game_records cfbd_game_team_stats
 #' @title CFBD Games Endpoint
-#' @description Get results, statistics and information for games
+#' @description Get results, statistics and information for games\cr
 #' \describe{
-#'   \item{`cfbd_game_info()`: Get results information from games}{.}
-#'   \item{`cfbd_calendar()`: Calendar - Returns calendar of weeks by season}{.}
-#'   \item{`cfbd_game_media()`: Get Game media information (TV, radio, etc)}{.}
-#'   \item{`cfbd_game_box_advanced()`: Get game advanced box score information}{.}
-#'   \item{`cfbd_game_player_stats()`: Get results information from games}{.}
-#'   \item{`cfbd_game_records()`: Get Team records by year}{.}
-#'   \item{`cfbd_game_team_stats()`: Get Team Statistics by Game}{.}
+#'   \item{`cfbd_game_info()`:}{Get results information from games.}
+#'   \item{`cfbd_calendar()`:}{Calendar - Returns calendar of weeks by season.}
+#'   \item{`cfbd_game_media()`:}{Get Game media information (TV, radio, etc).}
+#'   \item{`cfbd_game_box_advanced()`:}{Get game advanced box score information.}
+#'   \item{`cfbd_game_player_stats()`:}{Get results information from games.}
+#'   \item{`cfbd_game_records()`:}{Get Team records by year.}
+#'   \item{`cfbd_game_team_stats()`:}{Get Team Statistics by Game.}
 #' }
 #' @examples
 #' \donttest{
@@ -436,75 +436,75 @@ cfbd_game_media <- function(year,
 #' @param verbose Logical parameter (TRUE/FALSE, default: FALSE) to return warnings and messages from function
 #' @return [cfbd_game_box_advanced()] - A data frame with 2 rows and 69 variables:
 #' \describe{
-#'   \item{`team`: character.}{.}
-#'   \item{`plays`: double.}{.}
-#'   \item{`ppa_overall_total`: double.}{.}
-#'   \item{`ppa_overall_quarter1`: double.}{.}
-#'   \item{`ppa_overall_quarter2`: double.}{.}
-#'   \item{`ppa_overall_quarter3`: double.}{.}
-#'   \item{`ppa_overall_quarter4`: double.}{.}
-#'   \item{`ppa_passing_total`: double.}{.}
-#'   \item{`ppa_passing_quarter1`: double.}{.}
-#'   \item{`ppa_passing_quarter2`: double.}{.}
-#'   \item{`ppa_passing_quarter3`: double.}{.}
-#'   \item{`ppa_passing_quarter4`: double.}{.}
-#'   \item{`ppa_rushing_total`: double.}{.}
-#'   \item{`ppa_rushing_quarter1`: double.}{.}
-#'   \item{`ppa_rushing_quarter2`: double.}{.}
-#'   \item{`ppa_rushing_quarter3`: double.}{.}
-#'   \item{`ppa_rushing_quarter4`: double.}{.}
-#'   \item{`cumulative_ppa_plays`: double.}{.}
-#'   \item{`cumulative_ppa_overall_total`: double.}{.}
-#'   \item{`cumulative_ppa_overall_quarter1`: double.}{.}
-#'   \item{`cumulative_ppa_overall_quarter2`: double.}{.}
-#'   \item{`cumulative_ppa_overall_quarter3`: double.}{.}
-#'   \item{`cumulative_ppa_overall_quarter4`: double.}{.}
-#'   \item{`cumulative_ppa_passing_total`: double.}{.}
-#'   \item{`cumulative_ppa_passing_quarter1`: double.}{.}
-#'   \item{`cumulative_ppa_passing_quarter2`: double.}{.}
-#'   \item{`cumulative_ppa_passing_quarter3`: double.}{.}
-#'   \item{`cumulative_ppa_passing_quarter4`: double.}{.}
-#'   \item{`cumulative_ppa_rushing_total`: double.}{.}
-#'   \item{`cumulative_ppa_rushing_quarter1`: double.}{.}
-#'   \item{`cumulative_ppa_rushing_quarter2`: double.}{.}
-#'   \item{`cumulative_ppa_rushing_quarter3`: double.}{.}
-#'   \item{`cumulative_ppa_rushing_quarter4`: double.}{.}
-#'   \item{`success_rates_overall_total`: double.}{.}
-#'   \item{`success_rates_overall_quarter1`: double.}{.}
-#'   \item{`success_rates_overall_quarter2`: double.}{.}
-#'   \item{`success_rates_overall_quarter3`: double.}{.}
-#'   \item{`success_rates_overall_quarter4`: double.}{.}
-#'   \item{`success_rates_standard_downs_total`: double.}{.}
-#'   \item{`success_rates_standard_downs_quarter1`: double.}{.}
-#'   \item{`success_rates_standard_downs_quarter2`: double.}{.}
-#'   \item{`success_rates_standard_downs_quarter3`: double.}{.}
-#'   \item{`success_rates_standard_downs_quarter4`: double.}{.}
-#'   \item{`success_rates_passing_downs_total`: double.}{.}
-#'   \item{`success_rates_passing_downs_quarter1`: double.}{.}
-#'   \item{`success_rates_passing_downs_quarter2`: double.}{.}
-#'   \item{`success_rates_passing_downs_quarter3`: double.}{.}
-#'   \item{`success_rates_passing_downs_quarter4`: double.}{.}
-#'   \item{`explosiveness_overall_total`: double.}{.}
-#'   \item{`explosiveness_overall_quarter1`: double.}{.}
-#'   \item{`explosiveness_overall_quarter2`: double.}{.}
-#'   \item{`explosiveness_overall_quarter3`: double.}{.}
-#'   \item{`explosiveness_overall_quarter4`: double.}{.}
-#'   \item{`rushing_power_success`: double.}{.}
-#'   \item{`rushing_stuff_rate`: double.}{.}
-#'   \item{`rushing_line_yds`: double.}{.}
-#'   \item{`rushing_line_yd_avg`: double.}{.}
-#'   \item{`rushing_second_lvl_yds`: double.}{.}
-#'   \item{`rushing_second_lvl_yd_avg`: double.}{.}
-#'   \item{`rushing_open_field_yds`: double.}{.}
-#'   \item{`rushing_open_field_yd_avg`: double.}{.}
-#'   \item{`havoc_total`: double.}{.}
-#'   \item{`havoc_front_seven`: double.}{.}
-#'   \item{`havoc_db`: double.}{.}
-#'   \item{`scoring_opps_opportunities`: double.}{.}
-#'   \item{`scoring_opps_points`: double.}{.}
-#'   \item{`scoring_opps_pts_per_opp`: double.}{.}
-#'   \item{`field_pos_avg_start`: double.}{.}
-#'   \item{`field_pos_avg_starting_predicted_pts`: double.}{.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`plays`: double.}{Number of plays.}
+#'   \item{`ppa_overall_total`: double.}{Predicted points added (PPA) overall total.}
+#'   \item{`ppa_overall_quarter1`: double.}{Predicted points added (PPA) overall Q1.}
+#'   \item{`ppa_overall_quarter2`: double.}{Predicted points added (PPA) overall Q2.}
+#'   \item{`ppa_overall_quarter3`: double.}{Predicted points added (PPA) overall Q3.}
+#'   \item{`ppa_overall_quarter4`: double.}{Predicted points added (PPA) overall Q4.}
+#'   \item{`ppa_passing_total`: double.}{Passing predicted points added (PPA) total.}
+#'   \item{`ppa_passing_quarter1`: double.}{Passing predicted points added (PPA) Q1.}
+#'   \item{`ppa_passing_quarter2`: double.}{Passing predicted points added (PPA) Q2.}
+#'   \item{`ppa_passing_quarter3`: double.}{Passing predicted points added (PPA) Q3.}
+#'   \item{`ppa_passing_quarter4`: double.}{Passing predicted points added (PPA) Q4.}
+#'   \item{`ppa_rushing_total`: double.}{Rushing predicted points added (PPA) total.}
+#'   \item{`ppa_rushing_quarter1`: double.}{Rushing predicted points added (PPA) Q1.}
+#'   \item{`ppa_rushing_quarter2`: double.}{Rushing predicted points added (PPA) Q2.}
+#'   \item{`ppa_rushing_quarter3`: double.}{Rushing predicted points added (PPA) Q3.}
+#'   \item{`ppa_rushing_quarter4`: double.}{Rushing predicted points added (PPA) Q4.}
+#'   \item{`cumulative_ppa_plays`: double.}{Cumulative predicted points added (PPA) added total.}
+#'   \item{`cumulative_ppa_overall_total`: double.}{Cumulative predicted points added (PPA) total.}
+#'   \item{`cumulative_ppa_overall_quarter1`: double.}{Cumulative predicted points added (PPA) Q1.}
+#'   \item{`cumulative_ppa_overall_quarter2`: double.}{Cumulative predicted points added (PPA) Q2.}
+#'   \item{`cumulative_ppa_overall_quarter3`: double.}{Cumulative predicted points added (PPA) Q3.}
+#'   \item{`cumulative_ppa_overall_quarter4`: double.}{Cumulative predicted points added (PPA) Q4.}
+#'   \item{`cumulative_ppa_passing_total`: double.}{Cumulative passing predicted points added (PPA) total.}
+#'   \item{`cumulative_ppa_passing_quarter1`: double.}{Cumulative passing predicted points added (PPA) Q1.}
+#'   \item{`cumulative_ppa_passing_quarter2`: double.}{Cumulative passing predicted points added (PPA) Q2.}
+#'   \item{`cumulative_ppa_passing_quarter3`: double.}{Cumulative passing predicted points added (PPA) Q3.}
+#'   \item{`cumulative_ppa_passing_quarter4`: double.}{Cumulative passing predicted points added (PPA) Q4.}
+#'   \item{`cumulative_ppa_rushing_total`: double.}{Cumulative rushing predicted points added (PPA) total.}
+#'   \item{`cumulative_ppa_rushing_quarter1`: double.}{Cumulative rushing predicted points added (PPA) Q1.}
+#'   \item{`cumulative_ppa_rushing_quarter2`: double.}{Cumulative rushing predicted points added (PPA) Q2.}
+#'   \item{`cumulative_ppa_rushing_quarter3`: double.}{Cumulative rushing predicted points added (PPA) Q3.}
+#'   \item{`cumulative_ppa_rushing_quarter4`: double.}{Cumulative rushing predicted points added (PPA) Q4.}
+#'   \item{`success_rates_overall_total`: double.}{Success rates overall total.}
+#'   \item{`success_rates_overall_quarter1`: double.}{Success rates overall Q1.}
+#'   \item{`success_rates_overall_quarter2`: double.}{Success rates overall Q2.}
+#'   \item{`success_rates_overall_quarter3`: double.}{Success rates overall Q3.}
+#'   \item{`success_rates_overall_quarter4`: double.}{Success rates overall Q4.}
+#'   \item{`success_rates_standard_downs_total`: double.}{Success rates standard downs total.}
+#'   \item{`success_rates_standard_downs_quarter1`: double.}{Success rates standard downs Q1.}
+#'   \item{`success_rates_standard_downs_quarter2`: double.}{Success rates standard downs Q2.}
+#'   \item{`success_rates_standard_downs_quarter3`: double.}{Success rates standard downs Q3.}
+#'   \item{`success_rates_standard_downs_quarter4`: double.}{Success rates standard downs Q4.}
+#'   \item{`success_rates_passing_downs_total`: double.}{Success rates passing downs total.}
+#'   \item{`success_rates_passing_downs_quarter1`: double.}{Success rates passing downs Q1.}
+#'   \item{`success_rates_passing_downs_quarter2`: double.}{Success rates passing downs Q2.}
+#'   \item{`success_rates_passing_downs_quarter3`: double.}{Success rates passing downs Q3.}
+#'   \item{`success_rates_passing_downs_quarter4`: double.}{Success rates passing downs Q4.}
+#'   \item{`explosiveness_overall_total`: double.}{Explosiveness rates overall total.}
+#'   \item{`explosiveness_overall_quarter1`: double.}{Explosiveness rates overall Q1.}
+#'   \item{`explosiveness_overall_quarter2`: double.}{Explosiveness rates overall Q2.}
+#'   \item{`explosiveness_overall_quarter3`: double.}{Explosiveness rates overall Q3.}
+#'   \item{`explosiveness_overall_quarter4`: double.}{Explosiveness rates overall Q4.}
+#'   \item{`rushing_power_success`: double.}{Rushing power success rate.}
+#'   \item{`rushing_stuff_rate`: double.}{Rushing stuff rate.}
+#'   \item{`rushing_line_yds`: double.}{Rushing offensive line yards.}
+#'   \item{`rushing_line_yds_avg`: double.}{Rushing line yards average.}
+#'   \item{`rushing_second_lvl_yds`: double.}{Rushing second-level yards.}
+#'   \item{`rushing_second_lvl_yds_avg`: double.}{Average second level yards per rush.}
+#'   \item{`rushing_open_field_yds`: double.}{Rushing open field yards.}
+#'   \item{`rushing_open_field_yds_avg`: double.}{Average rushing open field yards average.}
+#'   \item{`havoc_total`: double.}{Total havoc rate.}
+#'   \item{`havoc_front_seven`: double.}{Front-7 players havoc rate.}
+#'   \item{`havoc_db`: double.}{Defensive back players havoc rate.}
+#'   \item{`scoring_opps_opportunities`: double.}{Number of scoring opportunities.}
+#'   \item{`scoring_opps_points`: double.}{Points on scoring opportunity drives.}
+#'   \item{`scoring_opps_pts_per_opp`: double.}{Points per scoring opportunity drives.}
+#'   \item{`field_pos_avg_start`: double.}{Average starting field position.}
+#'   \item{`field_pos_avg_starting_predicted_pts`: double.}{Average starting predicted points (PP) for the average starting field position.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/game/box/advanced}
 #' @keywords Game Advanced Box Score
@@ -609,9 +609,14 @@ cfbd_game_box_advanced <- function(game_id, long = FALSE,
           tidyr::pivot_wider(names_from = .data$stat, values_from = .data$value) %>%
           dplyr::select(-.data$name) %>%
           dplyr::mutate_all(as.numeric) %>%
-          dplyr::bind_cols(team) %>%
+          dplyr::bind_cols(team)  %>% 
           dplyr::select(.data$team, tidyr::everything()) %>%
           as.data.frame()
+        df <- df %>%
+          dplyr::rename(
+            rushing_line_yds_avg = .data$rushing_line_yd_avg,
+            rushing_second_lvl_yds_avg = .data$rushing_second_lvl_yd_avg,
+            rushing_open_field_yds_avg = .data$rushing_open_field_yd_avg)
       }
 
       if(verbose){
@@ -647,38 +652,38 @@ cfbd_game_box_advanced <- function(game_id, long = FALSE,
 #'
 #' @return [cfbd_game_player_stats()] - A data frame with 32 variables:
 #' \describe{
-#'   \item{`game_id`: integer.}{.}
-#'   \item{`team`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`home_away`: character.}{.}
-#'   \item{`points`: integer.}{.}
-#'   \item{`category`: character.}{.}
-#'   \item{`athlete_id`: character.}{.}
-#'   \item{`name`: character.}{.}
-#'   \item{`c_att`: character.}{.}
-#'   \item{`yds`: double.}{.}
-#'   \item{`avg`: double.}{.}
-#'   \item{`td`: double.}{.}
-#'   \item{`int`: double.}{.}
-#'   \item{`qbr`: double.}{.}
-#'   \item{`car`: double.}{.}
-#'   \item{`long`: double.}{.}
-#'   \item{`rec`: double.}{.}
-#'   \item{`no`: double.}{.}
-#'   \item{`fg`: character.}{.}
-#'   \item{`pct`: double.}{.}
-#'   \item{`xp`: character.}{.}
-#'   \item{`pts`: double.}{.}
-#'   \item{`tb`: double.}{.}
-#'   \item{`in_20`: double.}{.}
-#'   \item{`fum`: double.}{.}
-#'   \item{`lost`: double.}{.}
-#'   \item{`tot`: double.}{.}
-#'   \item{`solo`: double.}{.}
-#'   \item{`sacks`: double.}{.}
-#'   \item{`tfl`: double.}{.}
-#'   \item{`pd`: double.}{.}
-#'   \item{`qb_hur`: double.}{.}
+#'   \item{`game_id`: integer.}{Referencing game id.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of the team.}
+#'   \item{`home_away`: character.}{Flag for if the team was the home or away team.}
+#'   \item{`points`: integer.}{Team points.}
+#'   \item{`category`: character.}{Statistic category.}
+#'   \item{`athlete_id`: character.}{Athlete referencing id.}
+#'   \item{`name`: character.}{Player name.}
+#'   \item{`c_att`: character.}{Completions - Pass attempts.}
+#'   \item{`yds`: double.}{Statistic yardage.}
+#'   \item{`avg`: double.}{Average per statistic.}
+#'   \item{`td`: double.}{Touchdowns scored.}
+#'   \item{`int`: double.}{Interceptions thrown.}
+#'   \item{`qbr`: double.}{Quarterback rating.}
+#'   \item{`car`: double.}{Number of rushing carries.}
+#'   \item{`long`: double.}{Longest carry/reception of the game.}
+#'   \item{`rec`: double.}{Number of pass receptions.}
+#'   \item{`no`: double.}{Player number.}
+#'   \item{`fg`: character.}{Field goal attempts in the game.}
+#'   \item{`pct`: double.}{Field goal percentage in the game.}
+#'   \item{`xp`: character.}{Extra points kicked in the game.}
+#'   \item{`pts`: double.}{Total kicking points in the game.}
+#'   \item{`tb`: double.}{Touchbacks (for kicking) in the game.}
+#'   \item{`in_20`: double.}{Punts inside the 20 yardline in the game.}
+#'   \item{`fum`: double.}{Player fumbles in the game.}
+#'   \item{`lost`: double.}{Player fumbles lost in the game.}
+#'   \item{`tot`: double.}{Total tackles in the game.}
+#'   \item{`solo`: double.}{Solo tackles in the game.}
+#'   \item{`sacks`: double.}{Total sacks in the game.}
+#'   \item{`tfl`: double.}{Total tackles for loss in the game.}
+#'   \item{`pd`: double.}{Total passes defensed in the game.}
+#'   \item{`qb_hur`: double.}{Total quarterback hurries in the game.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/games/players}
 #' @keywords Game Info
@@ -863,26 +868,26 @@ cfbd_game_player_stats <- function(year,
 #' @param verbose Logical parameter (TRUE/FALSE, default: FALSE) to return warnings and messages from function
 #' @return [cfbd_game_records()] - A data frame with 20 variables:
 #' \describe{
-#'   \item{`year`: integer.}{.}
-#'   \item{`team`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`division`: character.}{.}
-#'   \item{`total_games`: integer.}{.}
-#'   \item{`total_wins`: integer.}{.}
-#'   \item{`total_losses`: integer.}{.}
-#'   \item{`total_ties`: integer.}{.}
-#'   \item{`conference_games`: integer.}{.}
-#'   \item{`conference_wins`: integer.}{.}
-#'   \item{`conference_losses`: integer.}{.}
-#'   \item{`conference_ties`: integer.}{.}
-#'   \item{`home_games`: integer.}{.}
-#'   \item{`home_wins`: integer.}{.}
-#'   \item{`home_losses`: integer.}{.}
-#'   \item{`home_ties`: integer.}{.}
-#'   \item{`away_games`: integer.}{.}
-#'   \item{`away_wins`: integer.}{.}
-#'   \item{`away_losses`: integer.}{.}
-#'   \item{`away_ties`: integer.}{.}
+#'   \item{`year`: integer.}{Season of the games.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of the team.}
+#'   \item{`division`: character.}{Division in the conference of the team.}
+#'   \item{`total_games`: integer.}{Total number of games played.}
+#'   \item{`total_wins`: integer.}{Total wins.}
+#'   \item{`total_losses`: integer.}{Total losses.}
+#'   \item{`total_ties`: integer.}{Total ties.}
+#'   \item{`conference_games`: integer.}{Number of conference games.}
+#'   \item{`conference_wins`: integer.}{Total conference wins.}
+#'   \item{`conference_losses`: integer.}{Total conference losses.}
+#'   \item{`conference_ties`: integer.}{Total conference ties.}
+#'   \item{`home_games`: integer.}{Total home games.}
+#'   \item{`home_wins`: integer.}{Total home wins.}
+#'   \item{`home_losses`: integer.}{Total home losses.}
+#'   \item{`home_ties`: integer.}{Total home ties.}
+#'   \item{`away_games`: integer.}{Total away games.}
+#'   \item{`away_wins`: integer.}{Total away wins.}
+#'   \item{`away_losses`: integer.}{Total away losses.}
+#'   \item{`away_ties`: integer.}{Total away ties.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/records}
 #' @keywords Team Info
@@ -1000,84 +1005,84 @@ cfbd_game_records <- function(year,
 #'
 #' @return [cfbd_game_team_stats()] - A data frame with 78 variables:
 #' \describe{
-#'   \item{`game_id`: integer.}{.}
-#'   \item{`school`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`home_away`: character.}{.}
-#'   \item{`points`: integer.}{.}
-#'   \item{`total_yards`: character.}{.}
-#'   \item{`net_passing_yards`: character.}{.}
-#'   \item{`completion_attempts`:character.}{.}
-#'   \item{`passing_tds`: character.}{.}
-#'   \item{`yards_per_pass`: character.}{.}
-#'   \item{`passes_intercepted`: character.}{.}
-#'   \item{`interception_yards`: character.}{.}
-#'   \item{`interception_tds`: character.}{.}
-#'   \item{`rushing_attempts`: character.}{.}
-#'   \item{`rushing_yards`: character.}{.}
-#'   \item{`rush_tds`: character.}{.}
-#'   \item{`yards_per_rush_attempt`: character.}{.}
-#'   \item{`first_downs`: character.}{.}
-#'   \item{`third_down_eff`: character.}{.}
-#'   \item{`fourth_down_eff`: character.}{.}
-#'   \item{`punt_returns`: character.}{.}
-#'   \item{`punt_return_yards`: character.}{.}
-#'   \item{`punt_return_tds`: character.}{.}
-#'   \item{`kick_return_yards`: character.}{.}
-#'   \item{`kick_return_tds`: character.}{.}
-#'   \item{`kick_returns`: character.}{.}
-#'   \item{`kicking_points`: character.}{.}
-#'   \item{`fumbles_recovered`: character.}{.}
-#'   \item{`fumbles_lost`: character.}{.}
-#'   \item{`total_fumbles`: character.}{.}
-#'   \item{`tackles`: character.}{.}
-#'   \item{`tackles_for_loss`: character.}{.}
-#'   \item{`sacks`: character.}{.}
-#'   \item{`qb_hurries`: character.}{.}
-#'   \item{`interceptions`: character.}{.}
-#'   \item{`passes_deflected`: character.}{.}
-#'   \item{`turnovers`: character.}{.}
-#'   \item{`defensive_tds`: character.}{.}
-#'   \item{`total_penalties_yards`: character.}{.}
-#'   \item{`possession_time`: character.}{.}
-#'   \item{`conference_allowed`: character.}{.}
-#'   \item{`home_away_allowed`: character.}{.}
-#'   \item{`points_allowed`: integer.}{.}
-#'   \item{`total_yards_allowed`: character.}{.}
-#'   \item{`net_passing_yards_allowed`: character.}{.}
-#'   \item{`completion_attempts_allowed`: character.}{.}
-#'   \item{`passing_tds_allowed`: character.}{.}
-#'   \item{`yards_per_pass_allowed`: character.}{.}
-#'   \item{`passes_intercepted_allowed`: character.}{.}
-#'   \item{`interception_yards_allowed`: character.}{.}
-#'   \item{`interception_tds_allowed`: character.}{.}
-#'   \item{`rushing_attempts_allowed`: character.}{.}
-#'   \item{`rushing_yards_allowed`: character.}{.}
-#'   \item{`rush_tds_allowed`: character.}{.}
-#'   \item{`yards_per_rush_attempt_allowed`: character.}{.}
-#'   \item{`first_downs_allowed`: character.}{.}
-#'   \item{`third_down_eff_allowed`: character.}{.}
-#'   \item{`fourth_down_eff_allowed`: character.}{.}
-#'   \item{`punt_returns_allowed`: character.}{.}
-#'   \item{`punt_return_yards_allowed`: character.}{.}
-#'   \item{`punt_return_tds_allowed`: character.}{.}
-#'   \item{`kick_return_yards_allowed`: character.}{.}
-#'   \item{`kick_return_tds_allowed`: character.}{.}
-#'   \item{`kick_returns_allowed`: character.}{.}
-#'   \item{`kicking_points_allowed`: character.}{.}
-#'   \item{`fumbles_recovered_allowed`: character.}{.}
-#'   \item{`fumbles_lost_allowed`: character.}{.}
-#'   \item{`total_fumbles_allowed`:character.}{.}
-#'   \item{`tackles_allowed`:character.}{.}
-#'   \item{`tackles_for_loss_allowed`: character.}{.}
-#'   \item{`sacks_allowed`: character.}{.}
-#'   \item{`qb_hurries_allowed`: character.}{.}
-#'   \item{`interceptions_allowed`: character.}{.}
-#'   \item{`passes_deflected_allowed`: character.}{.}
-#'   \item{`turnovers_allowed`: character.}{.}
-#'   \item{`defensive_tds_allowed`: character.}{.}
-#'   \item{`total_penalties_yards_allowed`: character.}{.}
-#'   \item{`possession_time_allowed`: character.}{.}
+#'   \item{`game_id`: integer.}{Referencing game id.}
+#'   \item{`school`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of the team.}
+#'   \item{`home_away`: character.}{Home/Away Flag.}
+#'   \item{`points`: integer.}{Team points.}
+#'   \item{`total_yards`: character.}{Team total yards.}
+#'   \item{`net_passing_yards`: character.}{Team net passing yards.}
+#'   \item{`completion_attempts`:character.}{Team completion attempts.}
+#'   \item{`passing_tds`: character.}{Team passing touchdowns.}
+#'   \item{`yards_per_pass`: character.}{Team game yards per pass.}
+#'   \item{`passes_intercepted`: character.}{Team passes intercepted.}
+#'   \item{`interception_yards`: character.}{Interception yards.}
+#'   \item{`interception_tds`: character.}{Interceptions returned for a touchdown.}
+#'   \item{`rushing_attempts`: character.}{Team rushing attempts. see also: ESTABLISH IT.}
+#'   \item{`rushing_yards`: character.}{Team rushing yards.}
+#'   \item{`rush_tds`: character.}{Team rushing touchdowns.}
+#'   \item{`yards_per_rush_attempt`: character.}{Team yards per rush attempt.}
+#'   \item{`first_downs`: character.}{First downs earned by the team.}
+#'   \item{`third_down_eff`: character.}{Third down efficiency.}
+#'   \item{`fourth_down_eff`: character.}{Fourth down efficiency.}
+#'   \item{`punt_returns`: character.}{Team punt returns.}
+#'   \item{`punt_return_yards`: character.}{Team punt return yards.}
+#'   \item{`punt_return_tds`: character.}{Team punt return touchdowns.}
+#'   \item{`kick_return_yards`: character.}{Team kick return yards.}
+#'   \item{`kick_return_tds`: character.}{Team kick return touchdowns.}
+#'   \item{`kick_returns`: character.}{Team kick returns.}
+#'   \item{`kicking_points`: character.}{Team points from kicking the ball.}
+#'   \item{`fumbles_recovered`: character.}{Team fumbles recovered.}
+#'   \item{`fumbles_lost`: character.}{Team fumbles lost.}
+#'   \item{`total_fumbles`: character.}{Team total fumbles.}
+#'   \item{`tackles`: character.}{Team tackles.}
+#'   \item{`tackles_for_loss`: character.}{Team tackles for a loss.}
+#'   \item{`sacks`: character.}{Team sacks.}
+#'   \item{`qb_hurries`: character.}{Team QB hurries.}
+#'   \item{`interceptions`: character.}{Team interceptions.}
+#'   \item{`passes_deflected`: character.}{Team passes deflected.}
+#'   \item{`turnovers`: character.}{Team turnovers.}
+#'   \item{`defensive_tds`: character.}{Team defensive touchdowns.}
+#'   \item{`total_penalties_yards`: character.}{Team total penalty yards.}
+#'   \item{`possession_time`: character.}{Team time of possession.}
+#'   \item{`conference_allowed`: character.}{Conference of the opponent team.}
+#'   \item{`home_away_allowed`: character.}{Flag for if the opponent was the home or away team.}
+#'   \item{`points_allowed`: integer.}{Points for the opponent.}
+#'   \item{`total_yards_allowed`: character.}{Opponent total yards.}
+#'   \item{`net_passing_yards_allowed`: character.}{Opponent net passing yards.}
+#'   \item{`completion_attempts_allowed`: character.}{Oppponent completion attempts.}
+#'   \item{`passing_tds_allowed`: character.}{Opponent passing TDs.}
+#'   \item{`yards_per_pass_allowed`: character.}{Opponent yards per pass allowed.}
+#'   \item{`passes_intercepted_allowed`: character.}{Opponent passes intercepted.}
+#'   \item{`interception_yards_allowed`: character.}{Opponent interception yards.}
+#'   \item{`interception_tds_allowed`: character.}{Opponent interception TDs.}
+#'   \item{`rushing_attempts_allowed`: character.}{Opponent rushing attempts.}
+#'   \item{`rushing_yards_allowed`: character.}{Opponent rushing yards.}
+#'   \item{`rush_tds_allowed`: character.}{Opponent rushing touchdownss.}
+#'   \item{`yards_per_rush_attempt_allowed`: character.}{Opponent rushing yards per attempt.}
+#'   \item{`first_downs_allowed`: character.}{Opponent first downs.}
+#'   \item{`third_down_eff_allowed`: character.}{Opponent third down efficiency.}
+#'   \item{`fourth_down_eff_allowed`: character.}{Opponent fourth down efficiency.}
+#'   \item{`punt_returns_allowed`: character.}{Opponent punt returns.}
+#'   \item{`punt_return_yards_allowed`: character.}{Opponent punt return yards.}
+#'   \item{`punt_return_tds_allowed`: character.}{Opponent punt return touchdowns.}
+#'   \item{`kick_return_yards_allowed`: character.}{Opponent kick return yards.}
+#'   \item{`kick_return_tds_allowed`: character.}{Opponent kick return touchdowns.}
+#'   \item{`kick_returns_allowed`: character.}{Opponent kick returns.}
+#'   \item{`kicking_points_allowed`: character.}{Opponent points from kicking.}
+#'   \item{`fumbles_recovered_allowed`: character.}{Opponent fumbles recovered.}
+#'   \item{`fumbles_lost_allowed`: character.}{Opponent fumbles lost.}
+#'   \item{`total_fumbles_allowed`:character.}{Opponent total number of fumbles.}
+#'   \item{`tackles_allowed`:character.}{Opponent tackles.}
+#'   \item{`tackles_for_loss_allowed`: character.}{Opponent tackles for loss.}
+#'   \item{`sacks_allowed`: character.}{Opponent sacks.}
+#'   \item{`qb_hurries_allowed`: character.}{Opponent quarterback hurries.}
+#'   \item{`interceptions_allowed`: character.}{Opponent interceptions.}
+#'   \item{`passes_deflected_allowed`: character.}{Opponent passes deflected.}
+#'   \item{`turnovers_allowed`: character.}{Opponent turnovers.}
+#'   \item{`defensive_tds_allowed`: character.}{Opponent defensive touchdowns.}
+#'   \item{`total_penalties_yards_allowed`: character.}{Opponent total penalty yards.}
+#'   \item{`possession_time_allowed`: character.}{Opponent time of possession.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/games/teams}
 #' @keywords Team Game Stats

--- a/R/cfbd_players.R
+++ b/R/cfbd_players.R
@@ -4,7 +4,7 @@
 #' @description 
 #' \describe{
 #' \item{`cfbd_player_info()`:}{Player Information Search.}
-#' \item{`cfbd_player_returning()`:}{Player Returning Production}
+#' \item{`cfbd_player_returning()`:}{Player Returning Production.}
 #' \item{`cfbd_player_usage()`:}{Player Usage.}
 #' }
 #' @param search_term (\emph{String} required): Search term for the player you are trying to look up

--- a/R/cfbd_ratings.R
+++ b/R/cfbd_ratings.R
@@ -4,10 +4,10 @@
 #' @title CFBD Ratings and Rankings Endpoints
 #' @description
 #' \describe{
-#' \item{`cfbd_rankings()`: Gets Historical CFB poll rankings at a specific week}{.}
-#' \item{`cfbd_ratings_sp()`: Get SP historical rating data}{.}
-#' \item{`cfbd_ratings_sp_conference()`: Get SP conference-level historical rating data}{.}
-#' \item{`cfbd_ratings_srs()`: Get SRS historical rating data}{.}
+#' \item{`cfbd_rankings()`:}{Gets Historical CFB poll rankings at a specific week.}
+#' \item{`cfbd_ratings_sp()`:}{Get SP historical rating data.}
+#' \item{`cfbd_ratings_sp_conference()`:}{Get SP conference-level historical rating data.}
+#' \item{`cfbd_ratings_srs()`:}{Get SRS historical rating data.}
 #' }
 #' @param year (\emph{Integer} required): Year, 4 digit format (\emph{YYYY})
 #' @param week (\emph{Integer} optional): Week, values from 1-15, 1-14 for seasons pre-playoff (i.e. 2013 or earlier)

--- a/R/cfbd_recruiting.R
+++ b/R/cfbd_recruiting.R
@@ -4,11 +4,11 @@
 #' @title CFB Recruiting Endpoint
 #' @description
 #' \describe{
-#'   \item{`cfbd_recruiting_player()`: Gets CFB recruiting information for a single year with filters available for team, recruit type, state and position.}{}
+#'   \item{`cfbd_recruiting_player()`:}{Gets CFB recruiting information for a single year with filters available for team, recruit type, state and position.}
 #'   
-#'   \item{`cfbd_recruiting_position()`: CFB Recruiting Information Position Groups.}{}
+#'   \item{`cfbd_recruiting_position()`:}{CFB Recruiting Information Position Groups.}
 #'   
-#'   \item{`cfbd_recruiting_team()`: CFB Recruiting Information Team Rankings.}{}
+#'   \item{`cfbd_recruiting_team()`:}{CFB Recruiting Information Team Rankings.}
 #' }
 #' 
 #' @details

--- a/R/cfbd_stats.R
+++ b/R/cfbd_stats.R
@@ -3,11 +3,11 @@
 #' @title CFBD Stats Endpoint
 #' @description 
 #' \describe{
-#' \item{`cfbd_stats_categories()`: College Football Mapping for Stats Categories}{.}
-#' \item{`cfbd_stats_season_team()`: Get Season Statistics by Team}{.}
-#' \item{`cfbd_stats_season_advanced()`: Get Season Advanced Statistics by Team}{.}
-#' \item{`cfbd_stats_game_advanced()`: Get Game Advanced Stats}{.}
-#' \item{`cfbd_stats_season_player()`: Get Season Statistics by Player}{.}
+#' \item{`cfbd_stats_categories()`:}{College Football Mapping for Stats Categories.}
+#' \item{`cfbd_stats_season_team()`:}{Get Season Statistics by Team.}
+#' \item{`cfbd_stats_season_advanced()`:}{Get Season Advanced Statistics by Team.}
+#' \item{`cfbd_stats_game_advanced()`:}{Get Game Advanced Stats.}
+#' \item{`cfbd_stats_season_player()`:}{Get Season Statistics by Player.}
 #' }
 #' @description [cfbd_stats_categories()] This function identifies all Stats Categories identified in the regular stats endpoint.
 #' @examples
@@ -65,7 +65,6 @@ cfbd_stats_categories <- function() {
   return(df)
 }
 
-
 #' Get Game Advanced Stats
 #' @rdname cfbd_stats
 #'
@@ -87,66 +86,66 @@ cfbd_stats_categories <- function() {
 #' }
 #' @return [cfbd_stats_game_advanced()] - A data frame with 60 variables:
 #' \describe{
-#'   \item{`game_id`: integer.}{.}
-#'   \item{`week`: integer.}{.}
-#'   \item{`team`: character.}{.}
-#'   \item{`opponent`: character.}{.}
-#'   \item{`off_plays`: integer.}{.}
-#'   \item{`off_drives`: integer.}{.}
-#'   \item{`off_ppa`: double.}{.}
-#'   \item{`off_total_ppa`: double.}{.}
-#'   \item{`off_success_rate`: double.}{.}
-#'   \item{`off_explosiveness`: double.}{.}
-#'   \item{`off_power_success`: double.}{.}
-#'   \item{`off_stuff_rate`: double.}{.}
-#'   \item{`off_line_yds`: double.}{.}
-#'   \item{`off_line_yds_total`: integer.}{.}
-#'   \item{`off_second_lvl_yds`: double.}{.}
-#'   \item{`off_second_lvl_yds_total`: integer.}{.}
-#'   \item{`off_open_field_yds`: integer.}{.}
-#'   \item{`off_open_field_yds_total`: integer.}{.}
-#'   \item{`off_standard_downs_ppa`: double.}{.}
-#'   \item{`off_standard_downs_success_rate`: double.}{.}
-#'   \item{`off_standard_downs_explosiveness`: double.}{.}
-#'   \item{`off_passing_downs_ppa`: double.}{.}
-#'   \item{`off_passing_downs_success_rate`: double.}{.}
-#'   \item{`off_passing_downs_explosiveness`: double.}{.}
-#'   \item{`off_rushing_plays_ppa`: double.}{.}
-#'   \item{`off_rushing_plays_total_ppa`: double.}{.}
-#'   \item{`off_rushing_plays_success_rate`: double.}{.}
-#'   \item{`off_rushing_plays_explosiveness`: double.}{.}
-#'   \item{`off_passing_plays_ppa`: double.}{.}
-#'   \item{`off_passing_plays_total_ppa`: double.}{.}
-#'   \item{`off_passing_plays_success_rate`: double.}{.}
-#'   \item{`off_passing_plays_explosiveness`: double.}{.}
-#'   \item{`def_plays`: integer.}{.}
-#'   \item{`def_drives`: integer.}{.}
-#'   \item{`def_ppa`: double.}{.}
-#'   \item{`def_total_ppa`: double.}{.}
-#'   \item{`def_success_rate`: double.}{.}
-#'   \item{`def_explosiveness`: double.}{.}
-#'   \item{`def_power_success`: double.}{.}
-#'   \item{`def_stuff_rate`: double.}{.}
-#'   \item{`def_line_yds`: double.}{.}
-#'   \item{`def_line_yds_total`: integer.}{.}
-#'   \item{`def_second_lvl_yds`: double.}{.}
-#'   \item{`def_second_lvl_yds_total`: integer.}{.}
-#'   \item{`def_open_field_yds`: double.}{.}
-#'   \item{`def_open_field_yds_total`: integer.}{.}
-#'   \item{`def_standard_downs_ppa`: double.}{.}
-#'   \item{`def_standard_downs_success_rate`: double.}{.}
-#'   \item{`def_standard_downs_explosiveness`: double.}{.}
-#'   \item{`def_passing_downs_ppa`: double.}{.}
-#'   \item{`def_passing_downs_success_rate`: double.}{.}
-#'   \item{`def_passing_downs_explosiveness`: double.}{.}
-#'   \item{`def_rushing_plays_ppa`: double.}{.}
-#'   \item{`def_rushing_plays_total_ppa`: double.}{.}
-#'   \item{`def_rushing_plays_success_rate`: double.}{.}
-#'   \item{`def_rushing_plays_explosiveness`: double.}{.}
-#'   \item{`def_passing_plays_ppa`: double.}{.}
-#'   \item{`def_passing_plays_total_ppa`: double.}{.}
-#'   \item{`def_passing_plays_success_rate`: double.}{.}
-#'   \item{`def_passing_plays_explosiveness`: double.}{.}
+#'   \item{`game_id`: integer.}{Referencing game id.}
+#'   \item{`week`: integer.}{Game week of the season.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`opponent`: character.}{Opponent team name.}
+#'   \item{`off_plays`: integer.}{Offense plays in the game.}
+#'   \item{`off_drives`: integer.}{Offense drives in the game.}
+#'   \item{`off_ppa`: double.}{Offense predicted points added (PPA).}
+#'   \item{`off_total_ppa`: double.}{Offense total predicted points added (PPA).}
+#'   \item{`off_success_rate`: double.}{Offense success rate.}
+#'   \item{`off_explosiveness`: double.}{Offense explosiveness rate.}
+#'   \item{`off_power_success`: double.}{Offense power success rate.}
+#'   \item{`off_stuff_rate`: double.}{Opponent stuff rate.}
+#'   \item{`off_line_yds`: double.}{Offensive line yards.}
+#'   \item{`off_line_yds_total`: integer.}{Offensive line yards total.}
+#'   \item{`off_second_lvl_yds`: double.}{Offense second-level yards.}
+#'   \item{`off_second_lvl_yds_total`: integer.}{Offense second-level yards total.}
+#'   \item{`off_open_field_yds`: integer.}{Offense open field yards.}
+#'   \item{`off_open_field_yds_total`: integer.}{Offense open field yards total.}
+#'   \item{`off_standard_downs_ppa`: double.}{Offense standard downs predicted points added (PPA).}
+#'   \item{`off_standard_downs_success_rate`: double.}{Offense standard downs success rate.}
+#'   \item{`off_standard_downs_explosiveness`: double.}{Offense standard downs explosiveness rate.}
+#'   \item{`off_passing_downs_ppa`: double.}{Offense passing downs predicted points added (PPA).}
+#'   \item{`off_passing_downs_success_rate`: double.}{Offense passing downs success rate.}
+#'   \item{`off_passing_downs_explosiveness`: double.}{Offense passing downs explosiveness rate.}
+#'   \item{`off_rushing_plays_ppa`: double.}{Offense rushing plays predicted points added (PPA).}
+#'   \item{`off_rushing_plays_total_ppa`: double.}{Offense rushing plays total predicted points added (PPA).}
+#'   \item{`off_rushing_plays_success_rate`: double.}{Offense rushing plays success rate.}
+#'   \item{`off_rushing_plays_explosiveness`: double.}{Offense rushing plays explosiveness rate.}
+#'   \item{`off_passing_plays_ppa`: double.}{Offense passing plays predicted points added (PPA).}
+#'   \item{`off_passing_plays_total_ppa`: double.}{Offense passing plays total predicted points added (PPA).}
+#'   \item{`off_passing_plays_success_rate`: double.}{Offense passing plays success rate.}
+#'   \item{`off_passing_plays_explosiveness`: double.}{Offense passing plays explosiveness rate.}
+#'   \item{`def_plays`: integer.}{Defense plays in the game.}
+#'   \item{`def_drives`: integer.}{Defense drives in the game.}
+#'   \item{`def_ppa`: double.}{Defense predicted points added (PPA).}
+#'   \item{`def_total_ppa`: double.}{Defense total predicted points added (PPA).}
+#'   \item{`def_success_rate`: double.}{Defense success rate.}
+#'   \item{`def_explosiveness`: double.}{Defense explosiveness rate.}
+#'   \item{`def_power_success`: double.}{Defense power success rate.}
+#'   \item{`def_stuff_rate`: double.}{Opponent stuff rate.}
+#'   \item{`def_line_yds`: double.}{Offensive line yards.}
+#'   \item{`def_line_yds_total`: integer.}{Offensive line yards total.}
+#'   \item{`def_second_lvl_yds`: double.}{Defense second-level yards.}
+#'   \item{`def_second_lvl_yds_total`: integer.}{Defense second-level yards total.}
+#'   \item{`def_open_field_yds`: integer.}{Defense open field yards.}
+#'   \item{`def_open_field_yds_total`: integer.}{Defense open field yards total.}
+#'   \item{`def_standard_downs_ppa`: double.}{Defense standard downs predicted points added (PPA).}
+#'   \item{`def_standard_downs_success_rate`: double.}{Defense standard downs success rate.}
+#'   \item{`def_standard_downs_explosiveness`: double.}{Defense standard downs explosiveness rate.}
+#'   \item{`def_passing_downs_ppa`: double.}{Defense passing downs predicted points added (PPA).}
+#'   \item{`def_passing_downs_success_rate`: double.}{Defense passing downs success rate.}
+#'   \item{`def_passing_downs_explosiveness`: double.}{Defense passing downs explosiveness rate.}
+#'   \item{`def_rushing_plays_ppa`: double.}{Defense rushing plays predicted points added (PPA).}
+#'   \item{`def_rushing_plays_total_ppa`: double.}{Defense rushing plays total predicted points added (PPA).}
+#'   \item{`def_rushing_plays_success_rate`: double.}{Defense rushing plays success rate.}
+#'   \item{`def_rushing_plays_explosiveness`: double.}{Defense rushing plays explosiveness rate.}
+#'   \item{`def_passing_plays_ppa`: double.}{Defense passing plays predicted points added (PPA).}
+#'   \item{`def_passing_plays_total_ppa`: double.}{Defense passing plays total predicted points added (PPA).}
+#'   \item{`def_passing_plays_success_rate`: double.}{Defense passing plays success rate.}
+#'   \item{`def_passing_plays_explosiveness`: double.}{Defense passing plays explosiveness rate.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/stats/game/advanced}
 #' @keywords Game Advanced Stats
@@ -281,7 +280,6 @@ cfbd_stats_game_advanced <- function(year,
   return(df)
 }
 
-
 #' Get Season Advanced Statistics by Team
 #' @rdname cfbd_stats
 #'
@@ -298,85 +296,85 @@ cfbd_stats_game_advanced <- function(year,
 #' }
 #' @return [cfbd_stats_season_advanced()] - A data frame with 79 variables:
 #' \describe{
-#'   \item{`season`: integer.}{.}
-#'   \item{`team`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`off_plays`: integer.}{.}
-#'   \item{`off_drives`: integer.}{.}
-#'   \item{`off_ppa`: double.}{.}
-#'   \item{`off_total_ppa`: double.}{.}
-#'   \item{`off_success_rate`: double.}{.}
-#'   \item{`off_explosiveness`: double.}{.}
-#'   \item{`off_power_success`: double.}{.}
-#'   \item{`off_stuff_rate`: double.}{.}
-#'   \item{`off_line_yds`: double.}{.}
-#'   \item{`off_line_yds_total`: integer.}{.}
-#'   \item{`off_second_lvl_yds`: double.}{.}
-#'   \item{`off_second_lvl_yds_total`: integer.}{.}
-#'   \item{`off_open_field_yds`: double.}{.}
-#'   \item{`off_open_field_yds_total`: integer.}{.}
-#'   \item{`off_pts_per_opp`: double.}{.}
-#'   \item{`off_field_pos_avg_start`: double.}{.}
-#'   \item{`off_field_pos_avg_predicted_points`: double.}{.}
-#'   \item{`off_havoc_total`: double.}{.}
-#'   \item{`off_havoc_front_seven`: double.}{.}
-#'   \item{`off_havoc_db`: double.}{.}
-#'   \item{`off_standard_downs_rate`: double.}{.}
-#'   \item{`off_standard_downs_ppa`: double.}{.}
-#'   \item{`off_standard_downs_success_rate`: double.}{.}
-#'   \item{`off_standard_downs_explosiveness`: double.}{.}
-#'   \item{`off_passing_downs_rate`: double.}{.}
-#'   \item{`off_passing_downs_ppa`: double.}{.}
-#'   \item{`off_passing_downs_success_rate`: double.}{.}
-#'   \item{`off_passing_downs_explosiveness`: double.}{.}
-#'   \item{`off_rushing_plays_rate`: double.}{.}
-#'   \item{`off_rushing_plays_ppa`: double.}{.}
-#'   \item{`off_rushing_plays_total_ppa`: double.}{.}
-#'   \item{`off_rushing_plays_success_rate`: double.}{.}
-#'   \item{`off_rushing_plays_explosiveness`: double.}{.}
-#'   \item{`off_passing_plays_rate`: double.}{.}
-#'   \item{`off_passing_plays_ppa`: double.}{.}
-#'   \item{`off_passing_plays_total_ppa`: double.}{.}
-#'   \item{`off_passing_plays_success_rate`: double.}{.}
-#'   \item{`off_passing_plays_explosiveness`: double.}{.}
-#'   \item{`def_plays`: integer.}{.}
-#'   \item{`def_drives`: integer.}{.}
-#'   \item{`def_ppa`: double.}{.}
-#'   \item{`def_total_ppa`: double.}{.}
-#'   \item{`def_success_rate`: double.}{.}
-#'   \item{`def_explosiveness`: double.}{.}
-#'   \item{`def_power_success`: double.}{.}
-#'   \item{`def_stuff_rate`: double.}{.}
-#'   \item{`def_line_yds`: double.}{.}
-#'   \item{`def_line_yds_total`: integer.}{.}
-#'   \item{`def_second_lvl_yds`: double.}{.}
-#'   \item{`def_second_lvl_yds_total`: integer.}{.}
-#'   \item{`def_open_field_yds`: double.}{.}
-#'   \item{`def_open_field_yds_total`: integer.}{.}
-#'   \item{`def_pts_per_opp`: double.}{.}
-#'   \item{`def_field_pos_avg_start`: integer.}{.}
-#'   \item{`def_field_pos_avg_predicted_points`: double.}{.}
-#'   \item{`def_havoc_total`: double.}{.}
-#'   \item{`def_havoc_front_seven`: double.}{.}
-#'   \item{`def_havoc_db`: double.}{.}
-#'   \item{`def_standard_downs_rate`: double.}{.}
-#'   \item{`def_standard_downs_ppa`: double.}{.}
-#'   \item{`def_standard_downs_success_rate`: double.}{.}
-#'   \item{`def_standard_downs_explosiveness`: double.}{.}
-#'   \item{`def_passing_downs_rate`: double.}{.}
-#'   \item{`def_passing_downs_ppa`: double.}{.}
-#'   \item{`def_passing_downs_total_ppa`: double.}{.}
-#'   \item{`def_passing_downs_success_rate`: double.}{.}
-#'   \item{`def_passing_downs_explosiveness`: double.}{.}
-#'   \item{`def_rushing_plays_rate`:double.}{.}
-#'   \item{`def_rushing_plays_ppa`:double.}{.}
-#'   \item{`def_rushing_plays_total_ppa`:double.}{.}
-#'   \item{`def_rushing_plays_success_rate`:double.}{.}
-#'   \item{`def_rushing_plays_explosiveness`:double.}{.}
-#'   \item{`def_passing_plays_rate`:double.}{.}
-#'   \item{`def_passing_plays_ppa`:double.}{.}
-#'   \item{`def_passing_plays_success_rate`:double.}{.}
-#'   \item{`def_passing_plays_explosiveness`:double.}{.}
+#'   \item{`season`: integer.}{Season of the statistics.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of the team.}
+#'   \item{`off_plays`: integer.}{Offense plays in the game.}
+#'   \item{`off_drives`: integer.}{Offense drives in the game.}
+#'   \item{`off_ppa`: double.}{Offense predicted points added (PPA).}
+#'   \item{`off_total_ppa`: double.}{Offense total predicted points added (PPA).}
+#'   \item{`off_success_rate`: double.}{Offense success rate.}
+#'   \item{`off_explosiveness`: double.}{Offense explosiveness rate.}
+#'   \item{`off_power_success`: double.}{Offense power success rate.}
+#'   \item{`off_stuff_rate`: double.}{Offense rushing stuff rate.}
+#'   \item{`off_line_yds`: double.}{Offensive line yards.}
+#'   \item{`off_line_yds_total`: integer.}{Offensive line yards total.}
+#'   \item{`off_second_lvl_yds`: double.}{Offense second-level yards.}
+#'   \item{`off_second_lvl_yds_total`: integer.}{Offense second-level yards total.}
+#'   \item{`off_open_field_yds`: integer.}{Offense open field yards.}
+#'   \item{`off_open_field_yds_total`: integer.}{Offense open field yards total.}
+#'   \item{`off_pts_per_opp`: double.}{Offense points per scoring opportunity.}
+#'   \item{`off_field_pos_avg_start`: double.}{Offense starting average field position.}
+#'   \item{`off_field_pos_avg_predicted_points`: double.}{Offense starting average field position predicted points (PP).}
+#'   \item{`off_havoc_total`: double.}{Offense havor rate total.}
+#'   \item{`off_havoc_front_seven`: double.}{Offense front-7 havoc rate.}
+#'   \item{`off_havoc_db`: double.}{Offense defensive back havor rate.}
+#'   \item{`off_standard_downs_rate`: double.}{Offense standard downs rate.}
+#'   \item{`off_standard_downs_ppa`: double.}{Offense standard downs predicted points added (PPA).}
+#'   \item{`off_standard_downs_success_rate`: double.}{Offense standard downs success rate.}
+#'   \item{`off_standard_downs_explosiveness`: double.}{Offense standard downs explosiveness rate.}
+#'   \item{`off_passing_downs_rate`: double.}{Offense passing downs rate.}
+#'   \item{`off_passing_downs_ppa`: double.}{Offense passing downs predicted points added (PPA).}
+#'   \item{`off_passing_downs_success_rate`: double.}{Offense passing downs success rate.}
+#'   \item{`off_passing_downs_explosiveness`: double.}{Offense passing downs explosiveness rate.}
+#'   \item{`off_rushing_plays_rate`: double.}{Offense rushing plays rate.}
+#'   \item{`off_rushing_plays_ppa`: double.}{Offense rushing plays predicted points added (PPA).}
+#'   \item{`off_rushing_plays_total_ppa`: double.}{Offense rushing plays total predicted points added (PPA).}
+#'   \item{`off_rushing_plays_success_rate`: double.}{Offense rushing plays success rate.}
+#'   \item{`off_rushing_plays_explosiveness`: double.}{Offense rushing plays explosiveness rate.}
+#'   \item{`off_passing_plays_rate`: double.}{Offense passing plays rate.}
+#'   \item{`off_passing_plays_ppa`: double.}{Offense passing plays predicted points added (PPA).}
+#'   \item{`off_passing_plays_total_ppa`: double.}{Offense passing plays total predicted points added (PPA).}
+#'   \item{`off_passing_plays_success_rate`: double.}{Offense passing plays success rate.}
+#'   \item{`off_passing_plays_explosiveness`: double.}{Offense passing plays explosiveness rate.}
+#'   \item{`def_plays`: integer.}{Defense plays in the game.}
+#'   \item{`def_drives`: integer.}{Defense drives in the game.}
+#'   \item{`def_ppa`: double.}{Defense predicted points added (PPA).}
+#'   \item{`def_total_ppa`: double.}{Defense total predicted points added (PPA).}
+#'   \item{`def_success_rate`: double.}{Defense success rate.}
+#'   \item{`def_explosiveness`: double.}{Defense explosiveness rate.}
+#'   \item{`def_power_success`: double.}{Defense power success rate.}
+#'   \item{`def_stuff_rate`: double.}{Defense rushing stuff rate.}
+#'   \item{`def_line_yds`: double.}{Defense Offensive line yards allowed.}
+#'   \item{`def_line_yds_total`: integer.}{Defense Offensive line yards total allowed.}
+#'   \item{`def_second_lvl_yds`: double.}{Defense second-level yards.}
+#'   \item{`def_second_lvl_yds_total`: integer.}{Defense second-level yards total.}
+#'   \item{`def_open_field_yds`: integer.}{Defense open field yards.}
+#'   \item{`def_open_field_yds_total`: integer.}{Defense open field yards total.}
+#'   \item{`def_pts_per_opp`: double.}{Defense points per scoring opportunity.}
+#'   \item{`def_field_pos_avg_start`: double.}{Defense starting average field position.}
+#'   \item{`def_field_pos_avg_predicted_points`: double.}{Defense starting average field position predicted points (PP).}
+#'   \item{`def_havoc_total`: double.}{Defense havor rate total.}
+#'   \item{`def_havoc_front_seven`: double.}{Defense front-7 havoc rate.}
+#'   \item{`def_havoc_db`: double.}{Defense defensive back havor rate.}
+#'   \item{`def_standard_downs_rate`: double.}{Defense standard downs rate.}
+#'   \item{`def_standard_downs_ppa`: double.}{Defense standard downs predicted points added (PPA).}
+#'   \item{`def_standard_downs_success_rate`: double.}{Defense standard downs success rate.}
+#'   \item{`def_standard_downs_explosiveness`: double.}{Defense standard downs explosiveness rate.}
+#'   \item{`def_passing_downs_rate`: double.}{Defense passing downs rate.}
+#'   \item{`def_passing_downs_ppa`: double.}{Defense passing downs predicted points added (PPA).}
+#'   \item{`def_passing_downs_success_rate`: double.}{Defense passing downs success rate.}
+#'   \item{`def_passing_downs_explosiveness`: double.}{Defense passing downs explosiveness rate.}
+#'   \item{`def_rushing_plays_rate`: double.}{Defense rushing plays rate.}
+#'   \item{`def_rushing_plays_ppa`: double.}{Defense rushing plays predicted points added (PPA).}
+#'   \item{`def_rushing_plays_total_ppa`: double.}{Defense rushing plays total predicted points added (PPA).}
+#'   \item{`def_rushing_plays_success_rate`: double.}{Defense rushing plays success rate.}
+#'   \item{`def_rushing_plays_explosiveness`: double.}{Defense rushing plays explosiveness rate.}
+#'   \item{`def_passing_plays_rate`: double.}{Defense passing plays rate.}
+#'   \item{`def_passing_plays_ppa`: double.}{Defense passing plays predicted points added (PPA).}
+#'   \item{`def_passing_plays_total_ppa`: double.}{Defense passing plays total predicted points added (PPA).}
+#'   \item{`def_passing_plays_success_rate`: double.}{Defense passing plays success rate.}
+#'   \item{`def_passing_plays_explosiveness`: double.}{Defense passing plays explosiveness rate.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/stats/season/advanced}
 #' @keywords Team Season Advanced Stats
@@ -534,65 +532,65 @@ cfbd_stats_season_advanced <- function(year,
 #' }
 #' @return [cfbd_stats_season_player()] - A data frame with 59 variables:
 #' \describe{
-#'   \item{`team`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`athlete_id`: character.}{.}
-#'   \item{`player`: character.}{.}
-#'   \item{`category`: character.}{.}
-#'   \item{`passing_completions`: double.}{.}
-#'   \item{`passing_att`: double.}{.}
-#'   \item{`passing_pct`: double.}{.}
-#'   \item{`passing_yds`: double.}{.}
-#'   \item{`passing_td`: double.}{.}
-#'   \item{`passing_int`: double.}{.}
-#'   \item{`passing_ypa`: double.}{.}
-#'   \item{`rushing_car`: double.}{.}
-#'   \item{`rushing_yds`: double.}{.}
-#'   \item{`rushing_td`: double.}{.}
-#'   \item{`rushing_ypc`: double.}{.}
-#'   \item{`rushing_long`: double.}{.}
-#'   \item{`receiving_rec`: double.}{.}
-#'   \item{`receiving_yds`: double.}{.}
-#'   \item{`receiving_td`: double.}{.}
-#'   \item{`receiving_ypr`: double.}{.}
-#'   \item{`receiving_long`: double.}{.}
-#'   \item{`fumbles_fum`: double.}{.}
-#'   \item{`fumbles_rec`: double.}{.}
-#'   \item{`fumbles_lost`: double.}{.}
-#'   \item{`defensive_solo`: double.}{.}
-#'   \item{`defensive_tot`: double.}{.}
-#'   \item{`defensive_tfl`: double.}{.}
-#'   \item{`defensive_sacks`: double.}{.}
-#'   \item{`defensive_qb_hur`: double.}{.}
-#'   \item{`interceptions_int`: double.}{.}
-#'   \item{`interceptions_yds`: double.}{.}
-#'   \item{`interceptions_avg`: double.}{.}
-#'   \item{`interceptions_td`: double.}{.}
-#'   \item{`defensive_pd`: double.}{.}
-#'   \item{`defensive_td`: double.}{.}
-#'   \item{`kicking_fgm`: double.}{.}
-#'   \item{`kicking_fga`: double.}{.}
-#'   \item{`kicking_pct`: double.}{.}
-#'   \item{`kicking_xpa`: double.}{.}
-#'   \item{`kicking_xpm`: double.}{.}
-#'   \item{`kicking_pts`: double.}{.}
-#'   \item{`kicking_long`: double.}{.}
-#'   \item{`kick_returns_no`: double.}{.}
-#'   \item{`kick_returns_yds`: double.}{.}
-#'   \item{`kick_returns_avg`: double.}{.}
-#'   \item{`kick_returns_td`: double.}{.}
-#'   \item{`kick_returns_long`: double.}{.}
-#'   \item{`punting_no`: double.}{.}
-#'   \item{`punting_yds`: double.}{.}
-#'   \item{`punting_ypp`: double.}{.}
-#'   \item{`punting_long`: double.}{.}
-#'   \item{`punting_in_20`: double.}{.}
-#'   \item{`punting_tb`: double.}{.}
-#'   \item{`punt_returns_no`: double.}{.}
-#'   \item{`punt_returns_yds`: double.}{.}
-#'   \item{`punt_returns_avg`: double.}{.}
-#'   \item{`punt_returns_td`: double.}{.}
-#'   \item{`punt_returns_long`: double.}{.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of the team.}
+#'   \item{`athlete_id`: character.}{Athlete referencing id.}
+#'   \item{`player`: character.}{Player name.}
+#'   \item{`category`: character.}{Statistic category.}
+#'   \item{`passing_completions`: double.}{Passing completions.}
+#'   \item{`passing_att`: double.}{Passing attempts.}
+#'   \item{`passing_pct`: double.}{Passing completion percentage.}
+#'   \item{`passing_yds`: double.}{Passing yardage.}
+#'   \item{`passing_td`: double.}{Passing touchdowns.}
+#'   \item{`passing_int`: double.}{Passing interceptions.}
+#'   \item{`passing_ypa`: double.}{Passing yards per attempt.}
+#'   \item{`rushing_car`: double.}{Rushing yards per carry.}
+#'   \item{`rushing_yds`: double.}{Rushing yards total.}
+#'   \item{`rushing_td`: double.}{Rushing touchdowns.}
+#'   \item{`rushing_ypc`: double.}{Rushing yards per carry.}
+#'   \item{`rushing_long`: double.}{Rushing longest yardage attempt.}
+#'   \item{`receiving_rec`: double.}{Receiving - pass receptions.}
+#'   \item{`receiving_yds`: double.}{Receiving - pass reception yards.}
+#'   \item{`receiving_td`: double.}{Receiving - passing reception touchdowns.}
+#'   \item{`receiving_ypr`: double.}{Receiving - passing yards per reception.}
+#'   \item{`receiving_long`: double.}{Receiving - longest pass reception yardage.}
+#'   \item{`fumbles_fum`: double.}{Fumbles.}
+#'   \item{`fumbles_rec`: double.}{Fumbles recovered.}
+#'   \item{`fumbles_lost`: double.}{Fumbles lost.}
+#'   \item{`defensive_solo`: double.}{Defensive solo tackles.}
+#'   \item{`defensive_tot`: double.}{Defensive total tackles.}
+#'   \item{`defensive_tfl`: double.}{Defensive tackles for loss.}
+#'   \item{`defensive_sacks`: double.}{Defensive sacks.}
+#'   \item{`defensive_qb_hur`: double.}{Defensive quarterback hurries.}
+#'   \item{`interceptions_int`: double.}{Interceptions total.}
+#'   \item{`interceptions_yds`: double.}{Interception return yards.}
+#'   \item{`interceptions_avg`: double.}{Interception return yards average.}
+#'   \item{`interceptions_td`: double.}{Interception return touchdowns.}
+#'   \item{`defensive_pd`: double.}{Defense - passes defensed.}
+#'   \item{`defensive_td`: double.}{Defense - defensive touchdowns.}
+#'   \item{`kicking_fgm`: double.}{Kicking - field goals made.}
+#'   \item{`kicking_fga`: double.}{Kicking - field goals attempted.}
+#'   \item{`kicking_pct`: double.}{Kicking - field goal percentage.}
+#'   \item{`kicking_xpa`: double.}{Kicking - extra points attempted.}
+#'   \item{`kicking_xpm`: double.}{Kicking - extra points made.}
+#'   \item{`kicking_pts`: double.}{Kicking - total points.}
+#'   \item{`kicking_long`: double.}{Kicking - longest successful field goal attempt.}
+#'   \item{`kick_returns_no`: double.}{Kick Returns - number of kick returns.}
+#'   \item{`kick_returns_yds`: double.}{Kick Returns - kick return yards.}
+#'   \item{`kick_returns_avg`: double.}{Kick Returns - kick return average yards per return.}
+#'   \item{`kick_returns_td`: double.}{Kick Returns - kick return touchdowns.}
+#'   \item{`kick_returns_long`: double.}{Kick Returns - longest kick return yardage.}
+#'   \item{`punting_no`: double.}{Punting - number of punts.}
+#'   \item{`punting_yds`: double.}{Punting - punting yardage.}
+#'   \item{`punting_ypp`: double.}{Punting - yards per punt.}
+#'   \item{`punting_long`: double.}{Punting - longest punt yardage.}
+#'   \item{`punting_in_20`: double.}{Punting - punt downed inside the 20 yard line.}
+#'   \item{`punting_tb`: double.}{Punting - punt caused a touchback.}
+#'   \item{`punt_returns_no`: double.}{Punt Returns - number of punt returns.}
+#'   \item{`punt_returns_yds`: double.}{Punt Returns - punt return yardage total.}
+#'   \item{`punt_returns_avg`: double.}{Punt Returns - punt return average yards per return.}
+#'   \item{`punt_returns_td`: double.}{Punt Returns - punt return touchdowns.}
+#'   \item{`punt_returns_long`: double.}{Punt Returns - longest punt return yardage.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/stats/player/season}
 #' @keywords Player Season Stats
@@ -802,52 +800,52 @@ cfbd_stats_season_player <- function(year,
 #' }
 #' @return [cfbd_stats_season_team()] - A data frame with 46 variables:
 #' \describe{
-#'   \item{`games`: integer.}{.}
-#'   \item{`team`: character.}{.}
-#'   \item{`conference`: character.}{.}
-#'   \item{`games`: integer.}{.}
-#'   \item{`time_of_poss_total`: integer.}{.}
-#'   \item{`time_of_poss_pg`: double.}{.}
-#'   \item{`pass_comps`: integer.}{.}
-#'   \item{`pass_atts`: integer.}{.}
-#'   \item{`completion_pct`: double.}{.}
-#'   \item{`net_pass_yds`: integer.}{.}
-#'   \item{`pass_ypa`: double.}{.}
-#'   \item{`pass_ypr`: double.}{.}
-#'   \item{`pass_TDs`: integer.}{.}
-#'   \item{`interceptions`: integer.}{.}
-#'   \item{`int_pct`: double.}{.}
-#'   \item{`rush_atts`: integer.}{.}
-#'   \item{`rush_yds`: integer.}{.}
-#'   \item{`rush_TDs`: integer.}{.}
-#'   \item{`rush_ypc`: double.}{.}
-#'   \item{`total_yds`: integer.}{.}
-#'   \item{`fumbles_lost`: integer.}{.}
-#'   \item{`turnovers`: integer.}{.}
-#'   \item{`turnovers_pg`: double.}{.}
-#'   \item{`first_downs`: integer.}{.}
-#'   \item{`third_downs`: integer.}{.}
-#'   \item{`third_down_convs`: integer.}{.}
-#'   \item{`third_conv_rate`: double.}{.}
-#'   \item{`fourth_down_convs`: integer.}{.}
-#'   \item{`fourth_downs`: integer.}{.}
-#'   \item{`fourth_conv_rate`: double.}{.}
-#'   \item{`penalties`: integer.}{.}
-#'   \item{`penalty_yds`: integer.}{.}
-#'   \item{`penalties_pg`: double.}{.}
-#'   \item{`penalty_yds_pg`: double.}{.}
-#'   \item{`yards_per_penalty`: double.}{.}
-#'   \item{`kick_returns`: integer.}{.}
-#'   \item{`kick_return_yds`: integer.}{.}
-#'   \item{`kick_return_TDs`: integer.}{.}
-#'   \item{`kick_return_avg`: double.}{.}
-#'   \item{`punt_returns`: integer.}{.}
-#'   \item{`punt_return_yds`: integer.}{.}
-#'   \item{`punt_return_TDs`: integer.}{.}
-#'   \item{`punt_return_avg`: double.}{.}
-#'   \item{`passes_intercepted`: integer.}{.}
-#'   \item{`passes_intercepted_yds`: integer.}{.}
-#'   \item{`passes_intercepted_TDs`: integer.}{.}
+#'   \item{`games`: integer.}{Number of games.}
+#'   \item{`team`: character.}{Team name.}
+#'   \item{`conference`: character.}{Conference of team.}
+#'   \item{`games`: integer.}{Number of games.}
+#'   \item{`time_of_poss_total`: integer.}{Time of possession total.}
+#'   \item{`time_of_poss_pg`: double.}{Time of possession per game.}
+#'   \item{`pass_comps`: integer.}{Total number of pass completions.}
+#'   \item{`pass_atts`: integer.}{Total number of pass attempts.}
+#'   \item{`completion_pct`: double.}{Passing completion percentage.}
+#'   \item{`net_pass_yds`: integer.}{Net passing yards.}
+#'   \item{`pass_ypa`: double.}{Passing yards per attempt.}
+#'   \item{`pass_ypr`: double.}{Passing yards per reception.}
+#'   \item{`pass_TDs`: integer.}{Passing touchdowns.}
+#'   \item{`interceptions`: integer.}{Passing interceptions.}
+#'   \item{`int_pct`: double.}{Interception percentage (of attempts).}
+#'   \item{`rush_atts`: integer.}{Rushing attempts.}
+#'   \item{`rush_yds`: integer.}{Rushing yards.}
+#'   \item{`rush_TDs`: integer.}{Rushing touchdowns.}
+#'   \item{`rush_ypc`: double.}{Rushing yards per carry.}
+#'   \item{`total_yds`: integer.}{Rushing total yards.}
+#'   \item{`fumbles_lost`: integer.}{Fumbles lost.}
+#'   \item{`turnovers`: integer.}{Turnovers total.}
+#'   \item{`turnovers_pg`: double.}{Turnovers per game.}
+#'   \item{`first_downs`: integer.}{Number of first downs.}
+#'   \item{`third_downs`: integer.}{Number of third downs.}
+#'   \item{`third_down_convs`: integer.}{Number of third down conversions.}
+#'   \item{`third_conv_rate`: double.}{Third down conversion rate.}
+#'   \item{`fourth_down_convs`: integer.}{Fourth down conversions.}
+#'   \item{`fourth_downs`: integer.}{Fourth downs.}
+#'   \item{`fourth_conv_rate`: double.}{Fourth down conversion rate.}
+#'   \item{`penalties`: integer.}{Total number of penalties.}
+#'   \item{`penalty_yds`: integer.}{Penalty yards total.}
+#'   \item{`penalties_pg`: double.}{Penalties per game.}
+#'   \item{`penalty_yds_pg`: double.}{Penalty yardage per game.}
+#'   \item{`yards_per_penalty`: double.}{Average yards per penalty.}
+#'   \item{`kick_returns`: integer.}{Number of kick returns.}
+#'   \item{`kick_return_yds`: integer.}{Total kick return yards.}
+#'   \item{`kick_return_TDs`: integer.}{Total kick return touchdowns.}
+#'   \item{`kick_return_avg`: double.}{Kick return yards average.}
+#'   \item{`punt_returns`: integer.}{Number of punt returns.}
+#'   \item{`punt_return_yds`: integer.}{Punt return total yards.}
+#'   \item{`punt_return_TDs`: integer.}{Punt return total touchdowns.}
+#'   \item{`punt_return_avg`: double.}{Punt return yards average.}
+#'   \item{`passes_intercepted`: integer.}{Passes intercepted.}
+#'   \item{`passes_intercepted_yds`: integer.}{Pass interception return yards.}
+#'   \item{`passes_intercepted_TDs`: integer.}{Pass interception return touchdowns.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/stats/season}
 #' @keywords Team Season Stats

--- a/R/cfbd_teams.R
+++ b/R/cfbd_teams.R
@@ -3,11 +3,11 @@
 #' @title CFBD Teams Endpoint
 #' @description 
 #' \describe{
-#' \item{`cfbd_team_info()`: Team Info Lookup}{.}
-#' \item{`cfbd_team_matchup_records()`: Get matchup history records between two teams.}{.}
-#' \item{`cfbd_team_matchup()`: Get matchup history between two teams.}{.}
-#' \item{`cfbd_team_roster()`: Get a team's full roster by year.}{.}
-#' \item{`cfbd_team_talent()`: Get composite team talent rankings for all teams in a given year}{.}
+#' \item{`cfbd_team_info()`:}{Team Info Lookup.}
+#' \item{`cfbd_team_matchup_records()`:}{Get matchup history records between two teams.}
+#' \item{`cfbd_team_matchup()`:}{Get matchup history between two teams.}
+#' \item{`cfbd_team_roster()`:}{Get a team's full roster by year.}
+#' \item{`cfbd_team_talent()`:}{Get composite team talent rankings for all teams in a given year.}
 #' }
 #' ## Team Info Lookup
 #'   Lists all teams in conference or all D-I teams if conference is left NULL
@@ -468,6 +468,7 @@ cfbd_team_matchup <- function(team1, team2, min_year = NULL, max_year = NULL,
 #'   \item{`home_latitude`: numeric.}{Hometown latitude.}
 #'   \item{`home_longitude`: number.}{Hometown longitude.}
 #'   \item{`home_county_fips`: integer.}{Hometown FIPS code.}
+#'   \item{`headshot_url`: character}{Player ESPN headshot url.}
 #' }
 #' @source \url{https://api.collegefootballdata.com/roster}
 #' @keywords Team Roster
@@ -535,9 +536,7 @@ cfbd_team_roster <- function(year, team = NULL,
         httr::content(as = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON() %>%
         dplyr::rename(athlete_id = .data$id) %>%
-        # Is this okay to just comment out?
-        # Changing to team = NULL deleted the column
-        # dplyr::mutate(team = team2) %>%
+        dplyr::mutate(headshot_url = paste0("https://a.espncdn.com/i/headshots/college-football/players/full/",.data$athlete_id,".png")) %>% 
         as.data.frame()
 
       if(verbose){ 

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,6 +73,20 @@ devtools::install_github(repo = "saiemgilani/cfbfastR")
 
 ## **Breaking Changes**
 
+### **v1.2.1**
+##### **Minor release**
+
+* Added headshot_url to outputs of [```cfbd_team_rosters```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_teams.html)
+
+* Renamed returns in [```cfbd_game_advanced()```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_games.html):
+  - `rushing_line_yd_avg` to plural `rushing_line_yds_avg`
+  - `rushing_second_lvl_yd_avg` to plural `rushing_second_lvl_yds_avg`
+  - `rushing_open_field_yd_avg` to plural `rushing_open_field_yds_avg`
+
+* Completed documentation for all returns except ```cfbd_pbp_data()```
+
+* Continued work on intro vignette
+
 ### **v1.2.0**
 #### **Add significant documentation to the package**
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -246,8 +246,8 @@ reference:
       - '`cfbd_venues`'
       - '`cfbd_conferences`'
       - '`cfbd_coaches`'
-  - subtitle: Internals
-    desc: Internal functions and helpers
+  - subtitle: Model functions and PBP helpers
+    desc: Model functions and play-by-play helpers
     contents:
       - '`create_epa`'
       - '`create_wpa`'

--- a/man/cfbd_games.Rd
+++ b/man/cfbd_games.Rd
@@ -169,229 +169,229 @@ Special Teams: punting, puntReturns, kicking, kickReturns\cr}
 
 \code{\link[=cfbd_game_box_advanced]{cfbd_game_box_advanced()}} - A data frame with 2 rows and 69 variables:
 \describe{
-\item{\code{team}: character.}{.}
-\item{\code{plays}: double.}{.}
-\item{\code{ppa_overall_total}: double.}{.}
-\item{\code{ppa_overall_quarter1}: double.}{.}
-\item{\code{ppa_overall_quarter2}: double.}{.}
-\item{\code{ppa_overall_quarter3}: double.}{.}
-\item{\code{ppa_overall_quarter4}: double.}{.}
-\item{\code{ppa_passing_total}: double.}{.}
-\item{\code{ppa_passing_quarter1}: double.}{.}
-\item{\code{ppa_passing_quarter2}: double.}{.}
-\item{\code{ppa_passing_quarter3}: double.}{.}
-\item{\code{ppa_passing_quarter4}: double.}{.}
-\item{\code{ppa_rushing_total}: double.}{.}
-\item{\code{ppa_rushing_quarter1}: double.}{.}
-\item{\code{ppa_rushing_quarter2}: double.}{.}
-\item{\code{ppa_rushing_quarter3}: double.}{.}
-\item{\code{ppa_rushing_quarter4}: double.}{.}
-\item{\code{cumulative_ppa_plays}: double.}{.}
-\item{\code{cumulative_ppa_overall_total}: double.}{.}
-\item{\code{cumulative_ppa_overall_quarter1}: double.}{.}
-\item{\code{cumulative_ppa_overall_quarter2}: double.}{.}
-\item{\code{cumulative_ppa_overall_quarter3}: double.}{.}
-\item{\code{cumulative_ppa_overall_quarter4}: double.}{.}
-\item{\code{cumulative_ppa_passing_total}: double.}{.}
-\item{\code{cumulative_ppa_passing_quarter1}: double.}{.}
-\item{\code{cumulative_ppa_passing_quarter2}: double.}{.}
-\item{\code{cumulative_ppa_passing_quarter3}: double.}{.}
-\item{\code{cumulative_ppa_passing_quarter4}: double.}{.}
-\item{\code{cumulative_ppa_rushing_total}: double.}{.}
-\item{\code{cumulative_ppa_rushing_quarter1}: double.}{.}
-\item{\code{cumulative_ppa_rushing_quarter2}: double.}{.}
-\item{\code{cumulative_ppa_rushing_quarter3}: double.}{.}
-\item{\code{cumulative_ppa_rushing_quarter4}: double.}{.}
-\item{\code{success_rates_overall_total}: double.}{.}
-\item{\code{success_rates_overall_quarter1}: double.}{.}
-\item{\code{success_rates_overall_quarter2}: double.}{.}
-\item{\code{success_rates_overall_quarter3}: double.}{.}
-\item{\code{success_rates_overall_quarter4}: double.}{.}
-\item{\code{success_rates_standard_downs_total}: double.}{.}
-\item{\code{success_rates_standard_downs_quarter1}: double.}{.}
-\item{\code{success_rates_standard_downs_quarter2}: double.}{.}
-\item{\code{success_rates_standard_downs_quarter3}: double.}{.}
-\item{\code{success_rates_standard_downs_quarter4}: double.}{.}
-\item{\code{success_rates_passing_downs_total}: double.}{.}
-\item{\code{success_rates_passing_downs_quarter1}: double.}{.}
-\item{\code{success_rates_passing_downs_quarter2}: double.}{.}
-\item{\code{success_rates_passing_downs_quarter3}: double.}{.}
-\item{\code{success_rates_passing_downs_quarter4}: double.}{.}
-\item{\code{explosiveness_overall_total}: double.}{.}
-\item{\code{explosiveness_overall_quarter1}: double.}{.}
-\item{\code{explosiveness_overall_quarter2}: double.}{.}
-\item{\code{explosiveness_overall_quarter3}: double.}{.}
-\item{\code{explosiveness_overall_quarter4}: double.}{.}
-\item{\code{rushing_power_success}: double.}{.}
-\item{\code{rushing_stuff_rate}: double.}{.}
-\item{\code{rushing_line_yds}: double.}{.}
-\item{\code{rushing_line_yd_avg}: double.}{.}
-\item{\code{rushing_second_lvl_yds}: double.}{.}
-\item{\code{rushing_second_lvl_yd_avg}: double.}{.}
-\item{\code{rushing_open_field_yds}: double.}{.}
-\item{\code{rushing_open_field_yd_avg}: double.}{.}
-\item{\code{havoc_total}: double.}{.}
-\item{\code{havoc_front_seven}: double.}{.}
-\item{\code{havoc_db}: double.}{.}
-\item{\code{scoring_opps_opportunities}: double.}{.}
-\item{\code{scoring_opps_points}: double.}{.}
-\item{\code{scoring_opps_pts_per_opp}: double.}{.}
-\item{\code{field_pos_avg_start}: double.}{.}
-\item{\code{field_pos_avg_starting_predicted_pts}: double.}{.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{plays}: double.}{Number of plays.}
+\item{\code{ppa_overall_total}: double.}{Predicted points added (PPA) overall total.}
+\item{\code{ppa_overall_quarter1}: double.}{Predicted points added (PPA) overall Q1.}
+\item{\code{ppa_overall_quarter2}: double.}{Predicted points added (PPA) overall Q2.}
+\item{\code{ppa_overall_quarter3}: double.}{Predicted points added (PPA) overall Q3.}
+\item{\code{ppa_overall_quarter4}: double.}{Predicted points added (PPA) overall Q4.}
+\item{\code{ppa_passing_total}: double.}{Passing predicted points added (PPA) total.}
+\item{\code{ppa_passing_quarter1}: double.}{Passing predicted points added (PPA) Q1.}
+\item{\code{ppa_passing_quarter2}: double.}{Passing predicted points added (PPA) Q2.}
+\item{\code{ppa_passing_quarter3}: double.}{Passing predicted points added (PPA) Q3.}
+\item{\code{ppa_passing_quarter4}: double.}{Passing predicted points added (PPA) Q4.}
+\item{\code{ppa_rushing_total}: double.}{Rushing predicted points added (PPA) total.}
+\item{\code{ppa_rushing_quarter1}: double.}{Rushing predicted points added (PPA) Q1.}
+\item{\code{ppa_rushing_quarter2}: double.}{Rushing predicted points added (PPA) Q2.}
+\item{\code{ppa_rushing_quarter3}: double.}{Rushing predicted points added (PPA) Q3.}
+\item{\code{ppa_rushing_quarter4}: double.}{Rushing predicted points added (PPA) Q4.}
+\item{\code{cumulative_ppa_plays}: double.}{Cumulative predicted points added (PPA) added total.}
+\item{\code{cumulative_ppa_overall_total}: double.}{Cumulative predicted points added (PPA) total.}
+\item{\code{cumulative_ppa_overall_quarter1}: double.}{Cumulative predicted points added (PPA) Q1.}
+\item{\code{cumulative_ppa_overall_quarter2}: double.}{Cumulative predicted points added (PPA) Q2.}
+\item{\code{cumulative_ppa_overall_quarter3}: double.}{Cumulative predicted points added (PPA) Q3.}
+\item{\code{cumulative_ppa_overall_quarter4}: double.}{Cumulative predicted points added (PPA) Q4.}
+\item{\code{cumulative_ppa_passing_total}: double.}{Cumulative passing predicted points added (PPA) total.}
+\item{\code{cumulative_ppa_passing_quarter1}: double.}{Cumulative passing predicted points added (PPA) Q1.}
+\item{\code{cumulative_ppa_passing_quarter2}: double.}{Cumulative passing predicted points added (PPA) Q2.}
+\item{\code{cumulative_ppa_passing_quarter3}: double.}{Cumulative passing predicted points added (PPA) Q3.}
+\item{\code{cumulative_ppa_passing_quarter4}: double.}{Cumulative passing predicted points added (PPA) Q4.}
+\item{\code{cumulative_ppa_rushing_total}: double.}{Cumulative rushing predicted points added (PPA) total.}
+\item{\code{cumulative_ppa_rushing_quarter1}: double.}{Cumulative rushing predicted points added (PPA) Q1.}
+\item{\code{cumulative_ppa_rushing_quarter2}: double.}{Cumulative rushing predicted points added (PPA) Q2.}
+\item{\code{cumulative_ppa_rushing_quarter3}: double.}{Cumulative rushing predicted points added (PPA) Q3.}
+\item{\code{cumulative_ppa_rushing_quarter4}: double.}{Cumulative rushing predicted points added (PPA) Q4.}
+\item{\code{success_rates_overall_total}: double.}{Success rates overall total.}
+\item{\code{success_rates_overall_quarter1}: double.}{Success rates overall Q1.}
+\item{\code{success_rates_overall_quarter2}: double.}{Success rates overall Q2.}
+\item{\code{success_rates_overall_quarter3}: double.}{Success rates overall Q3.}
+\item{\code{success_rates_overall_quarter4}: double.}{Success rates overall Q4.}
+\item{\code{success_rates_standard_downs_total}: double.}{Success rates standard downs total.}
+\item{\code{success_rates_standard_downs_quarter1}: double.}{Success rates standard downs Q1.}
+\item{\code{success_rates_standard_downs_quarter2}: double.}{Success rates standard downs Q2.}
+\item{\code{success_rates_standard_downs_quarter3}: double.}{Success rates standard downs Q3.}
+\item{\code{success_rates_standard_downs_quarter4}: double.}{Success rates standard downs Q4.}
+\item{\code{success_rates_passing_downs_total}: double.}{Success rates passing downs total.}
+\item{\code{success_rates_passing_downs_quarter1}: double.}{Success rates passing downs Q1.}
+\item{\code{success_rates_passing_downs_quarter2}: double.}{Success rates passing downs Q2.}
+\item{\code{success_rates_passing_downs_quarter3}: double.}{Success rates passing downs Q3.}
+\item{\code{success_rates_passing_downs_quarter4}: double.}{Success rates passing downs Q4.}
+\item{\code{explosiveness_overall_total}: double.}{Explosiveness rates overall total.}
+\item{\code{explosiveness_overall_quarter1}: double.}{Explosiveness rates overall Q1.}
+\item{\code{explosiveness_overall_quarter2}: double.}{Explosiveness rates overall Q2.}
+\item{\code{explosiveness_overall_quarter3}: double.}{Explosiveness rates overall Q3.}
+\item{\code{explosiveness_overall_quarter4}: double.}{Explosiveness rates overall Q4.}
+\item{\code{rushing_power_success}: double.}{Rushing power success rate.}
+\item{\code{rushing_stuff_rate}: double.}{Rushing stuff rate.}
+\item{\code{rushing_line_yds}: double.}{Rushing offensive line yards.}
+\item{\code{rushing_line_yds_avg}: double.}{Rushing line yards average.}
+\item{\code{rushing_second_lvl_yds}: double.}{Rushing second-level yards.}
+\item{\code{rushing_second_lvl_yds_avg}: double.}{Average second level yards per rush.}
+\item{\code{rushing_open_field_yds}: double.}{Rushing open field yards.}
+\item{\code{rushing_open_field_yds_avg}: double.}{Average rushing open field yards average.}
+\item{\code{havoc_total}: double.}{Total havoc rate.}
+\item{\code{havoc_front_seven}: double.}{Front-7 players havoc rate.}
+\item{\code{havoc_db}: double.}{Defensive back players havoc rate.}
+\item{\code{scoring_opps_opportunities}: double.}{Number of scoring opportunities.}
+\item{\code{scoring_opps_points}: double.}{Points on scoring opportunity drives.}
+\item{\code{scoring_opps_pts_per_opp}: double.}{Points per scoring opportunity drives.}
+\item{\code{field_pos_avg_start}: double.}{Average starting field position.}
+\item{\code{field_pos_avg_starting_predicted_pts}: double.}{Average starting predicted points (PP) for the average starting field position.}
 }
 
 \code{\link[=cfbd_game_player_stats]{cfbd_game_player_stats()}} - A data frame with 32 variables:
 \describe{
-\item{\code{game_id}: integer.}{.}
-\item{\code{team}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{home_away}: character.}{.}
-\item{\code{points}: integer.}{.}
-\item{\code{category}: character.}{.}
-\item{\code{athlete_id}: character.}{.}
-\item{\code{name}: character.}{.}
-\item{\code{c_att}: character.}{.}
-\item{\code{yds}: double.}{.}
-\item{\code{avg}: double.}{.}
-\item{\code{td}: double.}{.}
-\item{\code{int}: double.}{.}
-\item{\code{qbr}: double.}{.}
-\item{\code{car}: double.}{.}
-\item{\code{long}: double.}{.}
-\item{\code{rec}: double.}{.}
-\item{\code{no}: double.}{.}
-\item{\code{fg}: character.}{.}
-\item{\code{pct}: double.}{.}
-\item{\code{xp}: character.}{.}
-\item{\code{pts}: double.}{.}
-\item{\code{tb}: double.}{.}
-\item{\code{in_20}: double.}{.}
-\item{\code{fum}: double.}{.}
-\item{\code{lost}: double.}{.}
-\item{\code{tot}: double.}{.}
-\item{\code{solo}: double.}{.}
-\item{\code{sacks}: double.}{.}
-\item{\code{tfl}: double.}{.}
-\item{\code{pd}: double.}{.}
-\item{\code{qb_hur}: double.}{.}
+\item{\code{game_id}: integer.}{Referencing game id.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of the team.}
+\item{\code{home_away}: character.}{Flag for if the team was the home or away team.}
+\item{\code{points}: integer.}{Team points.}
+\item{\code{category}: character.}{Statistic category.}
+\item{\code{athlete_id}: character.}{Athlete referencing id.}
+\item{\code{name}: character.}{Player name.}
+\item{\code{c_att}: character.}{Completions - Pass attempts.}
+\item{\code{yds}: double.}{Statistic yardage.}
+\item{\code{avg}: double.}{Average per statistic.}
+\item{\code{td}: double.}{Touchdowns scored.}
+\item{\code{int}: double.}{Interceptions thrown.}
+\item{\code{qbr}: double.}{Quarterback rating.}
+\item{\code{car}: double.}{Number of rushing carries.}
+\item{\code{long}: double.}{Longest carry/reception of the game.}
+\item{\code{rec}: double.}{Number of pass receptions.}
+\item{\code{no}: double.}{Player number.}
+\item{\code{fg}: character.}{Field goal attempts in the game.}
+\item{\code{pct}: double.}{Field goal percentage in the game.}
+\item{\code{xp}: character.}{Extra points kicked in the game.}
+\item{\code{pts}: double.}{Total kicking points in the game.}
+\item{\code{tb}: double.}{Touchbacks (for kicking) in the game.}
+\item{\code{in_20}: double.}{Punts inside the 20 yardline in the game.}
+\item{\code{fum}: double.}{Player fumbles in the game.}
+\item{\code{lost}: double.}{Player fumbles lost in the game.}
+\item{\code{tot}: double.}{Total tackles in the game.}
+\item{\code{solo}: double.}{Solo tackles in the game.}
+\item{\code{sacks}: double.}{Total sacks in the game.}
+\item{\code{tfl}: double.}{Total tackles for loss in the game.}
+\item{\code{pd}: double.}{Total passes defensed in the game.}
+\item{\code{qb_hur}: double.}{Total quarterback hurries in the game.}
 }
 
 \code{\link[=cfbd_game_records]{cfbd_game_records()}} - A data frame with 20 variables:
 \describe{
-\item{\code{year}: integer.}{.}
-\item{\code{team}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{division}: character.}{.}
-\item{\code{total_games}: integer.}{.}
-\item{\code{total_wins}: integer.}{.}
-\item{\code{total_losses}: integer.}{.}
-\item{\code{total_ties}: integer.}{.}
-\item{\code{conference_games}: integer.}{.}
-\item{\code{conference_wins}: integer.}{.}
-\item{\code{conference_losses}: integer.}{.}
-\item{\code{conference_ties}: integer.}{.}
-\item{\code{home_games}: integer.}{.}
-\item{\code{home_wins}: integer.}{.}
-\item{\code{home_losses}: integer.}{.}
-\item{\code{home_ties}: integer.}{.}
-\item{\code{away_games}: integer.}{.}
-\item{\code{away_wins}: integer.}{.}
-\item{\code{away_losses}: integer.}{.}
-\item{\code{away_ties}: integer.}{.}
+\item{\code{year}: integer.}{Season of the games.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of the team.}
+\item{\code{division}: character.}{Division in the conference of the team.}
+\item{\code{total_games}: integer.}{Total number of games played.}
+\item{\code{total_wins}: integer.}{Total wins.}
+\item{\code{total_losses}: integer.}{Total losses.}
+\item{\code{total_ties}: integer.}{Total ties.}
+\item{\code{conference_games}: integer.}{Number of conference games.}
+\item{\code{conference_wins}: integer.}{Total conference wins.}
+\item{\code{conference_losses}: integer.}{Total conference losses.}
+\item{\code{conference_ties}: integer.}{Total conference ties.}
+\item{\code{home_games}: integer.}{Total home games.}
+\item{\code{home_wins}: integer.}{Total home wins.}
+\item{\code{home_losses}: integer.}{Total home losses.}
+\item{\code{home_ties}: integer.}{Total home ties.}
+\item{\code{away_games}: integer.}{Total away games.}
+\item{\code{away_wins}: integer.}{Total away wins.}
+\item{\code{away_losses}: integer.}{Total away losses.}
+\item{\code{away_ties}: integer.}{Total away ties.}
 }
 
 \code{\link[=cfbd_game_team_stats]{cfbd_game_team_stats()}} - A data frame with 78 variables:
 \describe{
-\item{\code{game_id}: integer.}{.}
-\item{\code{school}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{home_away}: character.}{.}
-\item{\code{points}: integer.}{.}
-\item{\code{total_yards}: character.}{.}
-\item{\code{net_passing_yards}: character.}{.}
-\item{\code{completion_attempts}:character.}{.}
-\item{\code{passing_tds}: character.}{.}
-\item{\code{yards_per_pass}: character.}{.}
-\item{\code{passes_intercepted}: character.}{.}
-\item{\code{interception_yards}: character.}{.}
-\item{\code{interception_tds}: character.}{.}
-\item{\code{rushing_attempts}: character.}{.}
-\item{\code{rushing_yards}: character.}{.}
-\item{\code{rush_tds}: character.}{.}
-\item{\code{yards_per_rush_attempt}: character.}{.}
-\item{\code{first_downs}: character.}{.}
-\item{\code{third_down_eff}: character.}{.}
-\item{\code{fourth_down_eff}: character.}{.}
-\item{\code{punt_returns}: character.}{.}
-\item{\code{punt_return_yards}: character.}{.}
-\item{\code{punt_return_tds}: character.}{.}
-\item{\code{kick_return_yards}: character.}{.}
-\item{\code{kick_return_tds}: character.}{.}
-\item{\code{kick_returns}: character.}{.}
-\item{\code{kicking_points}: character.}{.}
-\item{\code{fumbles_recovered}: character.}{.}
-\item{\code{fumbles_lost}: character.}{.}
-\item{\code{total_fumbles}: character.}{.}
-\item{\code{tackles}: character.}{.}
-\item{\code{tackles_for_loss}: character.}{.}
-\item{\code{sacks}: character.}{.}
-\item{\code{qb_hurries}: character.}{.}
-\item{\code{interceptions}: character.}{.}
-\item{\code{passes_deflected}: character.}{.}
-\item{\code{turnovers}: character.}{.}
-\item{\code{defensive_tds}: character.}{.}
-\item{\code{total_penalties_yards}: character.}{.}
-\item{\code{possession_time}: character.}{.}
-\item{\code{conference_allowed}: character.}{.}
-\item{\code{home_away_allowed}: character.}{.}
-\item{\code{points_allowed}: integer.}{.}
-\item{\code{total_yards_allowed}: character.}{.}
-\item{\code{net_passing_yards_allowed}: character.}{.}
-\item{\code{completion_attempts_allowed}: character.}{.}
-\item{\code{passing_tds_allowed}: character.}{.}
-\item{\code{yards_per_pass_allowed}: character.}{.}
-\item{\code{passes_intercepted_allowed}: character.}{.}
-\item{\code{interception_yards_allowed}: character.}{.}
-\item{\code{interception_tds_allowed}: character.}{.}
-\item{\code{rushing_attempts_allowed}: character.}{.}
-\item{\code{rushing_yards_allowed}: character.}{.}
-\item{\code{rush_tds_allowed}: character.}{.}
-\item{\code{yards_per_rush_attempt_allowed}: character.}{.}
-\item{\code{first_downs_allowed}: character.}{.}
-\item{\code{third_down_eff_allowed}: character.}{.}
-\item{\code{fourth_down_eff_allowed}: character.}{.}
-\item{\code{punt_returns_allowed}: character.}{.}
-\item{\code{punt_return_yards_allowed}: character.}{.}
-\item{\code{punt_return_tds_allowed}: character.}{.}
-\item{\code{kick_return_yards_allowed}: character.}{.}
-\item{\code{kick_return_tds_allowed}: character.}{.}
-\item{\code{kick_returns_allowed}: character.}{.}
-\item{\code{kicking_points_allowed}: character.}{.}
-\item{\code{fumbles_recovered_allowed}: character.}{.}
-\item{\code{fumbles_lost_allowed}: character.}{.}
-\item{\code{total_fumbles_allowed}:character.}{.}
-\item{\code{tackles_allowed}:character.}{.}
-\item{\code{tackles_for_loss_allowed}: character.}{.}
-\item{\code{sacks_allowed}: character.}{.}
-\item{\code{qb_hurries_allowed}: character.}{.}
-\item{\code{interceptions_allowed}: character.}{.}
-\item{\code{passes_deflected_allowed}: character.}{.}
-\item{\code{turnovers_allowed}: character.}{.}
-\item{\code{defensive_tds_allowed}: character.}{.}
-\item{\code{total_penalties_yards_allowed}: character.}{.}
-\item{\code{possession_time_allowed}: character.}{.}
+\item{\code{game_id}: integer.}{Referencing game id.}
+\item{\code{school}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of the team.}
+\item{\code{home_away}: character.}{Home/Away Flag.}
+\item{\code{points}: integer.}{Team points.}
+\item{\code{total_yards}: character.}{Team total yards.}
+\item{\code{net_passing_yards}: character.}{Team net passing yards.}
+\item{\code{completion_attempts}:character.}{Team completion attempts.}
+\item{\code{passing_tds}: character.}{Team passing touchdowns.}
+\item{\code{yards_per_pass}: character.}{Team game yards per pass.}
+\item{\code{passes_intercepted}: character.}{Team passes intercepted.}
+\item{\code{interception_yards}: character.}{Interception yards.}
+\item{\code{interception_tds}: character.}{Interceptions returned for a touchdown.}
+\item{\code{rushing_attempts}: character.}{Team rushing attempts. see also: ESTABLISH IT.}
+\item{\code{rushing_yards}: character.}{Team rushing yards.}
+\item{\code{rush_tds}: character.}{Team rushing touchdowns.}
+\item{\code{yards_per_rush_attempt}: character.}{Team yards per rush attempt.}
+\item{\code{first_downs}: character.}{First downs earned by the team.}
+\item{\code{third_down_eff}: character.}{Third down efficiency.}
+\item{\code{fourth_down_eff}: character.}{Fourth down efficiency.}
+\item{\code{punt_returns}: character.}{Team punt returns.}
+\item{\code{punt_return_yards}: character.}{Team punt return yards.}
+\item{\code{punt_return_tds}: character.}{Team punt return touchdowns.}
+\item{\code{kick_return_yards}: character.}{Team kick return yards.}
+\item{\code{kick_return_tds}: character.}{Team kick return touchdowns.}
+\item{\code{kick_returns}: character.}{Team kick returns.}
+\item{\code{kicking_points}: character.}{Team points from kicking the ball.}
+\item{\code{fumbles_recovered}: character.}{Team fumbles recovered.}
+\item{\code{fumbles_lost}: character.}{Team fumbles lost.}
+\item{\code{total_fumbles}: character.}{Team total fumbles.}
+\item{\code{tackles}: character.}{Team tackles.}
+\item{\code{tackles_for_loss}: character.}{Team tackles for a loss.}
+\item{\code{sacks}: character.}{Team sacks.}
+\item{\code{qb_hurries}: character.}{Team QB hurries.}
+\item{\code{interceptions}: character.}{Team interceptions.}
+\item{\code{passes_deflected}: character.}{Team passes deflected.}
+\item{\code{turnovers}: character.}{Team turnovers.}
+\item{\code{defensive_tds}: character.}{Team defensive touchdowns.}
+\item{\code{total_penalties_yards}: character.}{Team total penalty yards.}
+\item{\code{possession_time}: character.}{Team time of possession.}
+\item{\code{conference_allowed}: character.}{Conference of the opponent team.}
+\item{\code{home_away_allowed}: character.}{Flag for if the opponent was the home or away team.}
+\item{\code{points_allowed}: integer.}{Points for the opponent.}
+\item{\code{total_yards_allowed}: character.}{Opponent total yards.}
+\item{\code{net_passing_yards_allowed}: character.}{Opponent net passing yards.}
+\item{\code{completion_attempts_allowed}: character.}{Oppponent completion attempts.}
+\item{\code{passing_tds_allowed}: character.}{Opponent passing TDs.}
+\item{\code{yards_per_pass_allowed}: character.}{Opponent yards per pass allowed.}
+\item{\code{passes_intercepted_allowed}: character.}{Opponent passes intercepted.}
+\item{\code{interception_yards_allowed}: character.}{Opponent interception yards.}
+\item{\code{interception_tds_allowed}: character.}{Opponent interception TDs.}
+\item{\code{rushing_attempts_allowed}: character.}{Opponent rushing attempts.}
+\item{\code{rushing_yards_allowed}: character.}{Opponent rushing yards.}
+\item{\code{rush_tds_allowed}: character.}{Opponent rushing touchdownss.}
+\item{\code{yards_per_rush_attempt_allowed}: character.}{Opponent rushing yards per attempt.}
+\item{\code{first_downs_allowed}: character.}{Opponent first downs.}
+\item{\code{third_down_eff_allowed}: character.}{Opponent third down efficiency.}
+\item{\code{fourth_down_eff_allowed}: character.}{Opponent fourth down efficiency.}
+\item{\code{punt_returns_allowed}: character.}{Opponent punt returns.}
+\item{\code{punt_return_yards_allowed}: character.}{Opponent punt return yards.}
+\item{\code{punt_return_tds_allowed}: character.}{Opponent punt return touchdowns.}
+\item{\code{kick_return_yards_allowed}: character.}{Opponent kick return yards.}
+\item{\code{kick_return_tds_allowed}: character.}{Opponent kick return touchdowns.}
+\item{\code{kick_returns_allowed}: character.}{Opponent kick returns.}
+\item{\code{kicking_points_allowed}: character.}{Opponent points from kicking.}
+\item{\code{fumbles_recovered_allowed}: character.}{Opponent fumbles recovered.}
+\item{\code{fumbles_lost_allowed}: character.}{Opponent fumbles lost.}
+\item{\code{total_fumbles_allowed}:character.}{Opponent total number of fumbles.}
+\item{\code{tackles_allowed}:character.}{Opponent tackles.}
+\item{\code{tackles_for_loss_allowed}: character.}{Opponent tackles for loss.}
+\item{\code{sacks_allowed}: character.}{Opponent sacks.}
+\item{\code{qb_hurries_allowed}: character.}{Opponent quarterback hurries.}
+\item{\code{interceptions_allowed}: character.}{Opponent interceptions.}
+\item{\code{passes_deflected_allowed}: character.}{Opponent passes deflected.}
+\item{\code{turnovers_allowed}: character.}{Opponent turnovers.}
+\item{\code{defensive_tds_allowed}: character.}{Opponent defensive touchdowns.}
+\item{\code{total_penalties_yards_allowed}: character.}{Opponent total penalty yards.}
+\item{\code{possession_time_allowed}: character.}{Opponent time of possession.}
 }
 }
 \description{
-Get results, statistics and information for games
+Get results, statistics and information for games\cr
 \describe{
-\item{\code{cfbd_game_info()}: Get results information from games}{.}
-\item{\code{cfbd_calendar()}: Calendar - Returns calendar of weeks by season}{.}
-\item{\code{cfbd_game_media()}: Get Game media information (TV, radio, etc)}{.}
-\item{\code{cfbd_game_box_advanced()}: Get game advanced box score information}{.}
-\item{\code{cfbd_game_player_stats()}: Get results information from games}{.}
-\item{\code{cfbd_game_records()}: Get Team records by year}{.}
-\item{\code{cfbd_game_team_stats()}: Get Team Statistics by Game}{.}
+\item{\code{cfbd_game_info()}:}{Get results information from games.}
+\item{\code{cfbd_calendar()}:}{Calendar - Returns calendar of weeks by season.}
+\item{\code{cfbd_game_media()}:}{Get Game media information (TV, radio, etc).}
+\item{\code{cfbd_game_box_advanced()}:}{Get game advanced box score information.}
+\item{\code{cfbd_game_player_stats()}:}{Get results information from games.}
+\item{\code{cfbd_game_records()}:}{Get Team records by year.}
+\item{\code{cfbd_game_team_stats()}:}{Get Team Statistics by Game.}
 }
 }
 \examples{

--- a/man/cfbd_players.Rd
+++ b/man/cfbd_players.Rd
@@ -123,7 +123,7 @@ Can be found using the \code{\link[=cfbd_player_info]{cfbd_player_info()}} funct
 \description{
 \describe{
 \item{\code{cfbd_player_info()}:}{Player Information Search.}
-\item{\code{cfbd_player_returning()}:}{Player Returning Production}
+\item{\code{cfbd_player_returning()}:}{Player Returning Production.}
 \item{\code{cfbd_player_usage()}:}{Player Usage.}
 }
 }

--- a/man/cfbd_ratings.Rd
+++ b/man/cfbd_ratings.Rd
@@ -129,10 +129,10 @@ Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC}
 }
 \description{
 \describe{
-\item{\code{cfbd_rankings()}: Gets Historical CFB poll rankings at a specific week}{.}
-\item{\code{cfbd_ratings_sp()}: Get SP historical rating data}{.}
-\item{\code{cfbd_ratings_sp_conference()}: Get SP conference-level historical rating data}{.}
-\item{\code{cfbd_ratings_srs()}: Get SRS historical rating data}{.}
+\item{\code{cfbd_rankings()}:}{Gets Historical CFB poll rankings at a specific week.}
+\item{\code{cfbd_ratings_sp()}:}{Get SP historical rating data.}
+\item{\code{cfbd_ratings_sp_conference()}:}{Get SP conference-level historical rating data.}
+\item{\code{cfbd_ratings_srs()}:}{Get SRS historical rating data.}
 }
 
 At least one of \strong{year} or \strong{team} must be specified for the function to run

--- a/man/cfbd_recruiting.Rd
+++ b/man/cfbd_recruiting.Rd
@@ -104,11 +104,11 @@ Conference abbreviations G5 and FBS Independents: CUSA, MAC, MWC, Ind, SBC, AAC}
 }
 \description{
 \describe{
-\item{\code{cfbd_recruiting_player()}: Gets CFB recruiting information for a single year with filters available for team, recruit type, state and position.}{}
+\item{\code{cfbd_recruiting_player()}:}{Gets CFB recruiting information for a single year with filters available for team, recruit type, state and position.}
 
-\item{\code{cfbd_recruiting_position()}: CFB Recruiting Information Position Groups.}{}
+\item{\code{cfbd_recruiting_position()}:}{CFB Recruiting Information Position Groups.}
 
-\item{\code{cfbd_recruiting_team()}: CFB Recruiting Information Team Rankings.}{}
+\item{\code{cfbd_recruiting_team()}:}{CFB Recruiting Information Team Rankings.}
 }
 }
 \details{

--- a/man/cfbd_stats.Rd
+++ b/man/cfbd_stats.Rd
@@ -99,271 +99,271 @@ Special Teams: punting, puntReturns, kicking, kickReturns}
 
 \code{\link[=cfbd_stats_game_advanced]{cfbd_stats_game_advanced()}} - A data frame with 60 variables:
 \describe{
-\item{\code{game_id}: integer.}{.}
-\item{\code{week}: integer.}{.}
-\item{\code{team}: character.}{.}
-\item{\code{opponent}: character.}{.}
-\item{\code{off_plays}: integer.}{.}
-\item{\code{off_drives}: integer.}{.}
-\item{\code{off_ppa}: double.}{.}
-\item{\code{off_total_ppa}: double.}{.}
-\item{\code{off_success_rate}: double.}{.}
-\item{\code{off_explosiveness}: double.}{.}
-\item{\code{off_power_success}: double.}{.}
-\item{\code{off_stuff_rate}: double.}{.}
-\item{\code{off_line_yds}: double.}{.}
-\item{\code{off_line_yds_total}: integer.}{.}
-\item{\code{off_second_lvl_yds}: double.}{.}
-\item{\code{off_second_lvl_yds_total}: integer.}{.}
-\item{\code{off_open_field_yds}: integer.}{.}
-\item{\code{off_open_field_yds_total}: integer.}{.}
-\item{\code{off_standard_downs_ppa}: double.}{.}
-\item{\code{off_standard_downs_success_rate}: double.}{.}
-\item{\code{off_standard_downs_explosiveness}: double.}{.}
-\item{\code{off_passing_downs_ppa}: double.}{.}
-\item{\code{off_passing_downs_success_rate}: double.}{.}
-\item{\code{off_passing_downs_explosiveness}: double.}{.}
-\item{\code{off_rushing_plays_ppa}: double.}{.}
-\item{\code{off_rushing_plays_total_ppa}: double.}{.}
-\item{\code{off_rushing_plays_success_rate}: double.}{.}
-\item{\code{off_rushing_plays_explosiveness}: double.}{.}
-\item{\code{off_passing_plays_ppa}: double.}{.}
-\item{\code{off_passing_plays_total_ppa}: double.}{.}
-\item{\code{off_passing_plays_success_rate}: double.}{.}
-\item{\code{off_passing_plays_explosiveness}: double.}{.}
-\item{\code{def_plays}: integer.}{.}
-\item{\code{def_drives}: integer.}{.}
-\item{\code{def_ppa}: double.}{.}
-\item{\code{def_total_ppa}: double.}{.}
-\item{\code{def_success_rate}: double.}{.}
-\item{\code{def_explosiveness}: double.}{.}
-\item{\code{def_power_success}: double.}{.}
-\item{\code{def_stuff_rate}: double.}{.}
-\item{\code{def_line_yds}: double.}{.}
-\item{\code{def_line_yds_total}: integer.}{.}
-\item{\code{def_second_lvl_yds}: double.}{.}
-\item{\code{def_second_lvl_yds_total}: integer.}{.}
-\item{\code{def_open_field_yds}: double.}{.}
-\item{\code{def_open_field_yds_total}: integer.}{.}
-\item{\code{def_standard_downs_ppa}: double.}{.}
-\item{\code{def_standard_downs_success_rate}: double.}{.}
-\item{\code{def_standard_downs_explosiveness}: double.}{.}
-\item{\code{def_passing_downs_ppa}: double.}{.}
-\item{\code{def_passing_downs_success_rate}: double.}{.}
-\item{\code{def_passing_downs_explosiveness}: double.}{.}
-\item{\code{def_rushing_plays_ppa}: double.}{.}
-\item{\code{def_rushing_plays_total_ppa}: double.}{.}
-\item{\code{def_rushing_plays_success_rate}: double.}{.}
-\item{\code{def_rushing_plays_explosiveness}: double.}{.}
-\item{\code{def_passing_plays_ppa}: double.}{.}
-\item{\code{def_passing_plays_total_ppa}: double.}{.}
-\item{\code{def_passing_plays_success_rate}: double.}{.}
-\item{\code{def_passing_plays_explosiveness}: double.}{.}
+\item{\code{game_id}: integer.}{Referencing game id.}
+\item{\code{week}: integer.}{Game week of the season.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{opponent}: character.}{Opponent team name.}
+\item{\code{off_plays}: integer.}{Offense plays in the game.}
+\item{\code{off_drives}: integer.}{Offense drives in the game.}
+\item{\code{off_ppa}: double.}{Offense predicted points added (PPA).}
+\item{\code{off_total_ppa}: double.}{Offense total predicted points added (PPA).}
+\item{\code{off_success_rate}: double.}{Offense success rate.}
+\item{\code{off_explosiveness}: double.}{Offense explosiveness rate.}
+\item{\code{off_power_success}: double.}{Offense power success rate.}
+\item{\code{off_stuff_rate}: double.}{Opponent stuff rate.}
+\item{\code{off_line_yds}: double.}{Offensive line yards.}
+\item{\code{off_line_yds_total}: integer.}{Offensive line yards total.}
+\item{\code{off_second_lvl_yds}: double.}{Offense second-level yards.}
+\item{\code{off_second_lvl_yds_total}: integer.}{Offense second-level yards total.}
+\item{\code{off_open_field_yds}: integer.}{Offense open field yards.}
+\item{\code{off_open_field_yds_total}: integer.}{Offense open field yards total.}
+\item{\code{off_standard_downs_ppa}: double.}{Offense standard downs predicted points added (PPA).}
+\item{\code{off_standard_downs_success_rate}: double.}{Offense standard downs success rate.}
+\item{\code{off_standard_downs_explosiveness}: double.}{Offense standard downs explosiveness rate.}
+\item{\code{off_passing_downs_ppa}: double.}{Offense passing downs predicted points added (PPA).}
+\item{\code{off_passing_downs_success_rate}: double.}{Offense passing downs success rate.}
+\item{\code{off_passing_downs_explosiveness}: double.}{Offense passing downs explosiveness rate.}
+\item{\code{off_rushing_plays_ppa}: double.}{Offense rushing plays predicted points added (PPA).}
+\item{\code{off_rushing_plays_total_ppa}: double.}{Offense rushing plays total predicted points added (PPA).}
+\item{\code{off_rushing_plays_success_rate}: double.}{Offense rushing plays success rate.}
+\item{\code{off_rushing_plays_explosiveness}: double.}{Offense rushing plays explosiveness rate.}
+\item{\code{off_passing_plays_ppa}: double.}{Offense passing plays predicted points added (PPA).}
+\item{\code{off_passing_plays_total_ppa}: double.}{Offense passing plays total predicted points added (PPA).}
+\item{\code{off_passing_plays_success_rate}: double.}{Offense passing plays success rate.}
+\item{\code{off_passing_plays_explosiveness}: double.}{Offense passing plays explosiveness rate.}
+\item{\code{def_plays}: integer.}{Defense plays in the game.}
+\item{\code{def_drives}: integer.}{Defense drives in the game.}
+\item{\code{def_ppa}: double.}{Defense predicted points added (PPA).}
+\item{\code{def_total_ppa}: double.}{Defense total predicted points added (PPA).}
+\item{\code{def_success_rate}: double.}{Defense success rate.}
+\item{\code{def_explosiveness}: double.}{Defense explosiveness rate.}
+\item{\code{def_power_success}: double.}{Defense power success rate.}
+\item{\code{def_stuff_rate}: double.}{Opponent stuff rate.}
+\item{\code{def_line_yds}: double.}{Offensive line yards.}
+\item{\code{def_line_yds_total}: integer.}{Offensive line yards total.}
+\item{\code{def_second_lvl_yds}: double.}{Defense second-level yards.}
+\item{\code{def_second_lvl_yds_total}: integer.}{Defense second-level yards total.}
+\item{\code{def_open_field_yds}: integer.}{Defense open field yards.}
+\item{\code{def_open_field_yds_total}: integer.}{Defense open field yards total.}
+\item{\code{def_standard_downs_ppa}: double.}{Defense standard downs predicted points added (PPA).}
+\item{\code{def_standard_downs_success_rate}: double.}{Defense standard downs success rate.}
+\item{\code{def_standard_downs_explosiveness}: double.}{Defense standard downs explosiveness rate.}
+\item{\code{def_passing_downs_ppa}: double.}{Defense passing downs predicted points added (PPA).}
+\item{\code{def_passing_downs_success_rate}: double.}{Defense passing downs success rate.}
+\item{\code{def_passing_downs_explosiveness}: double.}{Defense passing downs explosiveness rate.}
+\item{\code{def_rushing_plays_ppa}: double.}{Defense rushing plays predicted points added (PPA).}
+\item{\code{def_rushing_plays_total_ppa}: double.}{Defense rushing plays total predicted points added (PPA).}
+\item{\code{def_rushing_plays_success_rate}: double.}{Defense rushing plays success rate.}
+\item{\code{def_rushing_plays_explosiveness}: double.}{Defense rushing plays explosiveness rate.}
+\item{\code{def_passing_plays_ppa}: double.}{Defense passing plays predicted points added (PPA).}
+\item{\code{def_passing_plays_total_ppa}: double.}{Defense passing plays total predicted points added (PPA).}
+\item{\code{def_passing_plays_success_rate}: double.}{Defense passing plays success rate.}
+\item{\code{def_passing_plays_explosiveness}: double.}{Defense passing plays explosiveness rate.}
 }
 
 \code{\link[=cfbd_stats_season_advanced]{cfbd_stats_season_advanced()}} - A data frame with 79 variables:
 \describe{
-\item{\code{season}: integer.}{.}
-\item{\code{team}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{off_plays}: integer.}{.}
-\item{\code{off_drives}: integer.}{.}
-\item{\code{off_ppa}: double.}{.}
-\item{\code{off_total_ppa}: double.}{.}
-\item{\code{off_success_rate}: double.}{.}
-\item{\code{off_explosiveness}: double.}{.}
-\item{\code{off_power_success}: double.}{.}
-\item{\code{off_stuff_rate}: double.}{.}
-\item{\code{off_line_yds}: double.}{.}
-\item{\code{off_line_yds_total}: integer.}{.}
-\item{\code{off_second_lvl_yds}: double.}{.}
-\item{\code{off_second_lvl_yds_total}: integer.}{.}
-\item{\code{off_open_field_yds}: double.}{.}
-\item{\code{off_open_field_yds_total}: integer.}{.}
-\item{\code{off_pts_per_opp}: double.}{.}
-\item{\code{off_field_pos_avg_start}: double.}{.}
-\item{\code{off_field_pos_avg_predicted_points}: double.}{.}
-\item{\code{off_havoc_total}: double.}{.}
-\item{\code{off_havoc_front_seven}: double.}{.}
-\item{\code{off_havoc_db}: double.}{.}
-\item{\code{off_standard_downs_rate}: double.}{.}
-\item{\code{off_standard_downs_ppa}: double.}{.}
-\item{\code{off_standard_downs_success_rate}: double.}{.}
-\item{\code{off_standard_downs_explosiveness}: double.}{.}
-\item{\code{off_passing_downs_rate}: double.}{.}
-\item{\code{off_passing_downs_ppa}: double.}{.}
-\item{\code{off_passing_downs_success_rate}: double.}{.}
-\item{\code{off_passing_downs_explosiveness}: double.}{.}
-\item{\code{off_rushing_plays_rate}: double.}{.}
-\item{\code{off_rushing_plays_ppa}: double.}{.}
-\item{\code{off_rushing_plays_total_ppa}: double.}{.}
-\item{\code{off_rushing_plays_success_rate}: double.}{.}
-\item{\code{off_rushing_plays_explosiveness}: double.}{.}
-\item{\code{off_passing_plays_rate}: double.}{.}
-\item{\code{off_passing_plays_ppa}: double.}{.}
-\item{\code{off_passing_plays_total_ppa}: double.}{.}
-\item{\code{off_passing_plays_success_rate}: double.}{.}
-\item{\code{off_passing_plays_explosiveness}: double.}{.}
-\item{\code{def_plays}: integer.}{.}
-\item{\code{def_drives}: integer.}{.}
-\item{\code{def_ppa}: double.}{.}
-\item{\code{def_total_ppa}: double.}{.}
-\item{\code{def_success_rate}: double.}{.}
-\item{\code{def_explosiveness}: double.}{.}
-\item{\code{def_power_success}: double.}{.}
-\item{\code{def_stuff_rate}: double.}{.}
-\item{\code{def_line_yds}: double.}{.}
-\item{\code{def_line_yds_total}: integer.}{.}
-\item{\code{def_second_lvl_yds}: double.}{.}
-\item{\code{def_second_lvl_yds_total}: integer.}{.}
-\item{\code{def_open_field_yds}: double.}{.}
-\item{\code{def_open_field_yds_total}: integer.}{.}
-\item{\code{def_pts_per_opp}: double.}{.}
-\item{\code{def_field_pos_avg_start}: integer.}{.}
-\item{\code{def_field_pos_avg_predicted_points}: double.}{.}
-\item{\code{def_havoc_total}: double.}{.}
-\item{\code{def_havoc_front_seven}: double.}{.}
-\item{\code{def_havoc_db}: double.}{.}
-\item{\code{def_standard_downs_rate}: double.}{.}
-\item{\code{def_standard_downs_ppa}: double.}{.}
-\item{\code{def_standard_downs_success_rate}: double.}{.}
-\item{\code{def_standard_downs_explosiveness}: double.}{.}
-\item{\code{def_passing_downs_rate}: double.}{.}
-\item{\code{def_passing_downs_ppa}: double.}{.}
-\item{\code{def_passing_downs_total_ppa}: double.}{.}
-\item{\code{def_passing_downs_success_rate}: double.}{.}
-\item{\code{def_passing_downs_explosiveness}: double.}{.}
-\item{\code{def_rushing_plays_rate}:double.}{.}
-\item{\code{def_rushing_plays_ppa}:double.}{.}
-\item{\code{def_rushing_plays_total_ppa}:double.}{.}
-\item{\code{def_rushing_plays_success_rate}:double.}{.}
-\item{\code{def_rushing_plays_explosiveness}:double.}{.}
-\item{\code{def_passing_plays_rate}:double.}{.}
-\item{\code{def_passing_plays_ppa}:double.}{.}
-\item{\code{def_passing_plays_success_rate}:double.}{.}
-\item{\code{def_passing_plays_explosiveness}:double.}{.}
+\item{\code{season}: integer.}{Season of the statistics.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of the team.}
+\item{\code{off_plays}: integer.}{Offense plays in the game.}
+\item{\code{off_drives}: integer.}{Offense drives in the game.}
+\item{\code{off_ppa}: double.}{Offense predicted points added (PPA).}
+\item{\code{off_total_ppa}: double.}{Offense total predicted points added (PPA).}
+\item{\code{off_success_rate}: double.}{Offense success rate.}
+\item{\code{off_explosiveness}: double.}{Offense explosiveness rate.}
+\item{\code{off_power_success}: double.}{Offense power success rate.}
+\item{\code{off_stuff_rate}: double.}{Offense rushing stuff rate.}
+\item{\code{off_line_yds}: double.}{Offensive line yards.}
+\item{\code{off_line_yds_total}: integer.}{Offensive line yards total.}
+\item{\code{off_second_lvl_yds}: double.}{Offense second-level yards.}
+\item{\code{off_second_lvl_yds_total}: integer.}{Offense second-level yards total.}
+\item{\code{off_open_field_yds}: integer.}{Offense open field yards.}
+\item{\code{off_open_field_yds_total}: integer.}{Offense open field yards total.}
+\item{\code{off_pts_per_opp}: double.}{Offense points per scoring opportunity.}
+\item{\code{off_field_pos_avg_start}: double.}{Offense starting average field position.}
+\item{\code{off_field_pos_avg_predicted_points}: double.}{Offense starting average field position predicted points (PP).}
+\item{\code{off_havoc_total}: double.}{Offense havor rate total.}
+\item{\code{off_havoc_front_seven}: double.}{Offense front-7 havoc rate.}
+\item{\code{off_havoc_db}: double.}{Offense defensive back havor rate.}
+\item{\code{off_standard_downs_rate}: double.}{Offense standard downs rate.}
+\item{\code{off_standard_downs_ppa}: double.}{Offense standard downs predicted points added (PPA).}
+\item{\code{off_standard_downs_success_rate}: double.}{Offense standard downs success rate.}
+\item{\code{off_standard_downs_explosiveness}: double.}{Offense standard downs explosiveness rate.}
+\item{\code{off_passing_downs_rate}: double.}{Offense passing downs rate.}
+\item{\code{off_passing_downs_ppa}: double.}{Offense passing downs predicted points added (PPA).}
+\item{\code{off_passing_downs_success_rate}: double.}{Offense passing downs success rate.}
+\item{\code{off_passing_downs_explosiveness}: double.}{Offense passing downs explosiveness rate.}
+\item{\code{off_rushing_plays_rate}: double.}{Offense rushing plays rate.}
+\item{\code{off_rushing_plays_ppa}: double.}{Offense rushing plays predicted points added (PPA).}
+\item{\code{off_rushing_plays_total_ppa}: double.}{Offense rushing plays total predicted points added (PPA).}
+\item{\code{off_rushing_plays_success_rate}: double.}{Offense rushing plays success rate.}
+\item{\code{off_rushing_plays_explosiveness}: double.}{Offense rushing plays explosiveness rate.}
+\item{\code{off_passing_plays_rate}: double.}{Offense passing plays rate.}
+\item{\code{off_passing_plays_ppa}: double.}{Offense passing plays predicted points added (PPA).}
+\item{\code{off_passing_plays_total_ppa}: double.}{Offense passing plays total predicted points added (PPA).}
+\item{\code{off_passing_plays_success_rate}: double.}{Offense passing plays success rate.}
+\item{\code{off_passing_plays_explosiveness}: double.}{Offense passing plays explosiveness rate.}
+\item{\code{def_plays}: integer.}{Defense plays in the game.}
+\item{\code{def_drives}: integer.}{Defense drives in the game.}
+\item{\code{def_ppa}: double.}{Defense predicted points added (PPA).}
+\item{\code{def_total_ppa}: double.}{Defense total predicted points added (PPA).}
+\item{\code{def_success_rate}: double.}{Defense success rate.}
+\item{\code{def_explosiveness}: double.}{Defense explosiveness rate.}
+\item{\code{def_power_success}: double.}{Defense power success rate.}
+\item{\code{def_stuff_rate}: double.}{Defense rushing stuff rate.}
+\item{\code{def_line_yds}: double.}{Defense Offensive line yards allowed.}
+\item{\code{def_line_yds_total}: integer.}{Defense Offensive line yards total allowed.}
+\item{\code{def_second_lvl_yds}: double.}{Defense second-level yards.}
+\item{\code{def_second_lvl_yds_total}: integer.}{Defense second-level yards total.}
+\item{\code{def_open_field_yds}: integer.}{Defense open field yards.}
+\item{\code{def_open_field_yds_total}: integer.}{Defense open field yards total.}
+\item{\code{def_pts_per_opp}: double.}{Defense points per scoring opportunity.}
+\item{\code{def_field_pos_avg_start}: double.}{Defense starting average field position.}
+\item{\code{def_field_pos_avg_predicted_points}: double.}{Defense starting average field position predicted points (PP).}
+\item{\code{def_havoc_total}: double.}{Defense havor rate total.}
+\item{\code{def_havoc_front_seven}: double.}{Defense front-7 havoc rate.}
+\item{\code{def_havoc_db}: double.}{Defense defensive back havor rate.}
+\item{\code{def_standard_downs_rate}: double.}{Defense standard downs rate.}
+\item{\code{def_standard_downs_ppa}: double.}{Defense standard downs predicted points added (PPA).}
+\item{\code{def_standard_downs_success_rate}: double.}{Defense standard downs success rate.}
+\item{\code{def_standard_downs_explosiveness}: double.}{Defense standard downs explosiveness rate.}
+\item{\code{def_passing_downs_rate}: double.}{Defense passing downs rate.}
+\item{\code{def_passing_downs_ppa}: double.}{Defense passing downs predicted points added (PPA).}
+\item{\code{def_passing_downs_success_rate}: double.}{Defense passing downs success rate.}
+\item{\code{def_passing_downs_explosiveness}: double.}{Defense passing downs explosiveness rate.}
+\item{\code{def_rushing_plays_rate}: double.}{Defense rushing plays rate.}
+\item{\code{def_rushing_plays_ppa}: double.}{Defense rushing plays predicted points added (PPA).}
+\item{\code{def_rushing_plays_total_ppa}: double.}{Defense rushing plays total predicted points added (PPA).}
+\item{\code{def_rushing_plays_success_rate}: double.}{Defense rushing plays success rate.}
+\item{\code{def_rushing_plays_explosiveness}: double.}{Defense rushing plays explosiveness rate.}
+\item{\code{def_passing_plays_rate}: double.}{Defense passing plays rate.}
+\item{\code{def_passing_plays_ppa}: double.}{Defense passing plays predicted points added (PPA).}
+\item{\code{def_passing_plays_total_ppa}: double.}{Defense passing plays total predicted points added (PPA).}
+\item{\code{def_passing_plays_success_rate}: double.}{Defense passing plays success rate.}
+\item{\code{def_passing_plays_explosiveness}: double.}{Defense passing plays explosiveness rate.}
 }
 
 \code{\link[=cfbd_stats_season_player]{cfbd_stats_season_player()}} - A data frame with 59 variables:
 \describe{
-\item{\code{team}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{athlete_id}: character.}{.}
-\item{\code{player}: character.}{.}
-\item{\code{category}: character.}{.}
-\item{\code{passing_completions}: double.}{.}
-\item{\code{passing_att}: double.}{.}
-\item{\code{passing_pct}: double.}{.}
-\item{\code{passing_yds}: double.}{.}
-\item{\code{passing_td}: double.}{.}
-\item{\code{passing_int}: double.}{.}
-\item{\code{passing_ypa}: double.}{.}
-\item{\code{rushing_car}: double.}{.}
-\item{\code{rushing_yds}: double.}{.}
-\item{\code{rushing_td}: double.}{.}
-\item{\code{rushing_ypc}: double.}{.}
-\item{\code{rushing_long}: double.}{.}
-\item{\code{receiving_rec}: double.}{.}
-\item{\code{receiving_yds}: double.}{.}
-\item{\code{receiving_td}: double.}{.}
-\item{\code{receiving_ypr}: double.}{.}
-\item{\code{receiving_long}: double.}{.}
-\item{\code{fumbles_fum}: double.}{.}
-\item{\code{fumbles_rec}: double.}{.}
-\item{\code{fumbles_lost}: double.}{.}
-\item{\code{defensive_solo}: double.}{.}
-\item{\code{defensive_tot}: double.}{.}
-\item{\code{defensive_tfl}: double.}{.}
-\item{\code{defensive_sacks}: double.}{.}
-\item{\code{defensive_qb_hur}: double.}{.}
-\item{\code{interceptions_int}: double.}{.}
-\item{\code{interceptions_yds}: double.}{.}
-\item{\code{interceptions_avg}: double.}{.}
-\item{\code{interceptions_td}: double.}{.}
-\item{\code{defensive_pd}: double.}{.}
-\item{\code{defensive_td}: double.}{.}
-\item{\code{kicking_fgm}: double.}{.}
-\item{\code{kicking_fga}: double.}{.}
-\item{\code{kicking_pct}: double.}{.}
-\item{\code{kicking_xpa}: double.}{.}
-\item{\code{kicking_xpm}: double.}{.}
-\item{\code{kicking_pts}: double.}{.}
-\item{\code{kicking_long}: double.}{.}
-\item{\code{kick_returns_no}: double.}{.}
-\item{\code{kick_returns_yds}: double.}{.}
-\item{\code{kick_returns_avg}: double.}{.}
-\item{\code{kick_returns_td}: double.}{.}
-\item{\code{kick_returns_long}: double.}{.}
-\item{\code{punting_no}: double.}{.}
-\item{\code{punting_yds}: double.}{.}
-\item{\code{punting_ypp}: double.}{.}
-\item{\code{punting_long}: double.}{.}
-\item{\code{punting_in_20}: double.}{.}
-\item{\code{punting_tb}: double.}{.}
-\item{\code{punt_returns_no}: double.}{.}
-\item{\code{punt_returns_yds}: double.}{.}
-\item{\code{punt_returns_avg}: double.}{.}
-\item{\code{punt_returns_td}: double.}{.}
-\item{\code{punt_returns_long}: double.}{.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of the team.}
+\item{\code{athlete_id}: character.}{Athlete referencing id.}
+\item{\code{player}: character.}{Player name.}
+\item{\code{category}: character.}{Statistic category.}
+\item{\code{passing_completions}: double.}{Passing completions.}
+\item{\code{passing_att}: double.}{Passing attempts.}
+\item{\code{passing_pct}: double.}{Passing completion percentage.}
+\item{\code{passing_yds}: double.}{Passing yardage.}
+\item{\code{passing_td}: double.}{Passing touchdowns.}
+\item{\code{passing_int}: double.}{Passing interceptions.}
+\item{\code{passing_ypa}: double.}{Passing yards per attempt.}
+\item{\code{rushing_car}: double.}{Rushing yards per carry.}
+\item{\code{rushing_yds}: double.}{Rushing yards total.}
+\item{\code{rushing_td}: double.}{Rushing touchdowns.}
+\item{\code{rushing_ypc}: double.}{Rushing yards per carry.}
+\item{\code{rushing_long}: double.}{Rushing longest yardage attempt.}
+\item{\code{receiving_rec}: double.}{Receiving - pass receptions.}
+\item{\code{receiving_yds}: double.}{Receiving - pass reception yards.}
+\item{\code{receiving_td}: double.}{Receiving - passing reception touchdowns.}
+\item{\code{receiving_ypr}: double.}{Receiving - passing yards per reception.}
+\item{\code{receiving_long}: double.}{Receiving - longest pass reception yardage.}
+\item{\code{fumbles_fum}: double.}{Fumbles.}
+\item{\code{fumbles_rec}: double.}{Fumbles recovered.}
+\item{\code{fumbles_lost}: double.}{Fumbles lost.}
+\item{\code{defensive_solo}: double.}{Defensive solo tackles.}
+\item{\code{defensive_tot}: double.}{Defensive total tackles.}
+\item{\code{defensive_tfl}: double.}{Defensive tackles for loss.}
+\item{\code{defensive_sacks}: double.}{Defensive sacks.}
+\item{\code{defensive_qb_hur}: double.}{Defensive quarterback hurries.}
+\item{\code{interceptions_int}: double.}{Interceptions total.}
+\item{\code{interceptions_yds}: double.}{Interception return yards.}
+\item{\code{interceptions_avg}: double.}{Interception return yards average.}
+\item{\code{interceptions_td}: double.}{Interception return touchdowns.}
+\item{\code{defensive_pd}: double.}{Defense - passes defensed.}
+\item{\code{defensive_td}: double.}{Defense - defensive touchdowns.}
+\item{\code{kicking_fgm}: double.}{Kicking - field goals made.}
+\item{\code{kicking_fga}: double.}{Kicking - field goals attempted.}
+\item{\code{kicking_pct}: double.}{Kicking - field goal percentage.}
+\item{\code{kicking_xpa}: double.}{Kicking - extra points attempted.}
+\item{\code{kicking_xpm}: double.}{Kicking - extra points made.}
+\item{\code{kicking_pts}: double.}{Kicking - total points.}
+\item{\code{kicking_long}: double.}{Kicking - longest successful field goal attempt.}
+\item{\code{kick_returns_no}: double.}{Kick Returns - number of kick returns.}
+\item{\code{kick_returns_yds}: double.}{Kick Returns - kick return yards.}
+\item{\code{kick_returns_avg}: double.}{Kick Returns - kick return average yards per return.}
+\item{\code{kick_returns_td}: double.}{Kick Returns - kick return touchdowns.}
+\item{\code{kick_returns_long}: double.}{Kick Returns - longest kick return yardage.}
+\item{\code{punting_no}: double.}{Punting - number of punts.}
+\item{\code{punting_yds}: double.}{Punting - punting yardage.}
+\item{\code{punting_ypp}: double.}{Punting - yards per punt.}
+\item{\code{punting_long}: double.}{Punting - longest punt yardage.}
+\item{\code{punting_in_20}: double.}{Punting - punt downed inside the 20 yard line.}
+\item{\code{punting_tb}: double.}{Punting - punt caused a touchback.}
+\item{\code{punt_returns_no}: double.}{Punt Returns - number of punt returns.}
+\item{\code{punt_returns_yds}: double.}{Punt Returns - punt return yardage total.}
+\item{\code{punt_returns_avg}: double.}{Punt Returns - punt return average yards per return.}
+\item{\code{punt_returns_td}: double.}{Punt Returns - punt return touchdowns.}
+\item{\code{punt_returns_long}: double.}{Punt Returns - longest punt return yardage.}
 }
 
 \code{\link[=cfbd_stats_season_team]{cfbd_stats_season_team()}} - A data frame with 46 variables:
 \describe{
-\item{\code{games}: integer.}{.}
-\item{\code{team}: character.}{.}
-\item{\code{conference}: character.}{.}
-\item{\code{games}: integer.}{.}
-\item{\code{time_of_poss_total}: integer.}{.}
-\item{\code{time_of_poss_pg}: double.}{.}
-\item{\code{pass_comps}: integer.}{.}
-\item{\code{pass_atts}: integer.}{.}
-\item{\code{completion_pct}: double.}{.}
-\item{\code{net_pass_yds}: integer.}{.}
-\item{\code{pass_ypa}: double.}{.}
-\item{\code{pass_ypr}: double.}{.}
-\item{\code{pass_TDs}: integer.}{.}
-\item{\code{interceptions}: integer.}{.}
-\item{\code{int_pct}: double.}{.}
-\item{\code{rush_atts}: integer.}{.}
-\item{\code{rush_yds}: integer.}{.}
-\item{\code{rush_TDs}: integer.}{.}
-\item{\code{rush_ypc}: double.}{.}
-\item{\code{total_yds}: integer.}{.}
-\item{\code{fumbles_lost}: integer.}{.}
-\item{\code{turnovers}: integer.}{.}
-\item{\code{turnovers_pg}: double.}{.}
-\item{\code{first_downs}: integer.}{.}
-\item{\code{third_downs}: integer.}{.}
-\item{\code{third_down_convs}: integer.}{.}
-\item{\code{third_conv_rate}: double.}{.}
-\item{\code{fourth_down_convs}: integer.}{.}
-\item{\code{fourth_downs}: integer.}{.}
-\item{\code{fourth_conv_rate}: double.}{.}
-\item{\code{penalties}: integer.}{.}
-\item{\code{penalty_yds}: integer.}{.}
-\item{\code{penalties_pg}: double.}{.}
-\item{\code{penalty_yds_pg}: double.}{.}
-\item{\code{yards_per_penalty}: double.}{.}
-\item{\code{kick_returns}: integer.}{.}
-\item{\code{kick_return_yds}: integer.}{.}
-\item{\code{kick_return_TDs}: integer.}{.}
-\item{\code{kick_return_avg}: double.}{.}
-\item{\code{punt_returns}: integer.}{.}
-\item{\code{punt_return_yds}: integer.}{.}
-\item{\code{punt_return_TDs}: integer.}{.}
-\item{\code{punt_return_avg}: double.}{.}
-\item{\code{passes_intercepted}: integer.}{.}
-\item{\code{passes_intercepted_yds}: integer.}{.}
-\item{\code{passes_intercepted_TDs}: integer.}{.}
+\item{\code{games}: integer.}{Number of games.}
+\item{\code{team}: character.}{Team name.}
+\item{\code{conference}: character.}{Conference of team.}
+\item{\code{games}: integer.}{Number of games.}
+\item{\code{time_of_poss_total}: integer.}{Time of possession total.}
+\item{\code{time_of_poss_pg}: double.}{Time of possession per game.}
+\item{\code{pass_comps}: integer.}{Total number of pass completions.}
+\item{\code{pass_atts}: integer.}{Total number of pass attempts.}
+\item{\code{completion_pct}: double.}{Passing completion percentage.}
+\item{\code{net_pass_yds}: integer.}{Net passing yards.}
+\item{\code{pass_ypa}: double.}{Passing yards per attempt.}
+\item{\code{pass_ypr}: double.}{Passing yards per reception.}
+\item{\code{pass_TDs}: integer.}{Passing touchdowns.}
+\item{\code{interceptions}: integer.}{Passing interceptions.}
+\item{\code{int_pct}: double.}{Interception percentage (of attempts).}
+\item{\code{rush_atts}: integer.}{Rushing attempts.}
+\item{\code{rush_yds}: integer.}{Rushing yards.}
+\item{\code{rush_TDs}: integer.}{Rushing touchdowns.}
+\item{\code{rush_ypc}: double.}{Rushing yards per carry.}
+\item{\code{total_yds}: integer.}{Rushing total yards.}
+\item{\code{fumbles_lost}: integer.}{Fumbles lost.}
+\item{\code{turnovers}: integer.}{Turnovers total.}
+\item{\code{turnovers_pg}: double.}{Turnovers per game.}
+\item{\code{first_downs}: integer.}{Number of first downs.}
+\item{\code{third_downs}: integer.}{Number of third downs.}
+\item{\code{third_down_convs}: integer.}{Number of third down conversions.}
+\item{\code{third_conv_rate}: double.}{Third down conversion rate.}
+\item{\code{fourth_down_convs}: integer.}{Fourth down conversions.}
+\item{\code{fourth_downs}: integer.}{Fourth downs.}
+\item{\code{fourth_conv_rate}: double.}{Fourth down conversion rate.}
+\item{\code{penalties}: integer.}{Total number of penalties.}
+\item{\code{penalty_yds}: integer.}{Penalty yards total.}
+\item{\code{penalties_pg}: double.}{Penalties per game.}
+\item{\code{penalty_yds_pg}: double.}{Penalty yardage per game.}
+\item{\code{yards_per_penalty}: double.}{Average yards per penalty.}
+\item{\code{kick_returns}: integer.}{Number of kick returns.}
+\item{\code{kick_return_yds}: integer.}{Total kick return yards.}
+\item{\code{kick_return_TDs}: integer.}{Total kick return touchdowns.}
+\item{\code{kick_return_avg}: double.}{Kick return yards average.}
+\item{\code{punt_returns}: integer.}{Number of punt returns.}
+\item{\code{punt_return_yds}: integer.}{Punt return total yards.}
+\item{\code{punt_return_TDs}: integer.}{Punt return total touchdowns.}
+\item{\code{punt_return_avg}: double.}{Punt return yards average.}
+\item{\code{passes_intercepted}: integer.}{Passes intercepted.}
+\item{\code{passes_intercepted_yds}: integer.}{Pass interception return yards.}
+\item{\code{passes_intercepted_TDs}: integer.}{Pass interception return touchdowns.}
 }
 }
 \description{
 \describe{
-\item{\code{cfbd_stats_categories()}: College Football Mapping for Stats Categories}{.}
-\item{\code{cfbd_stats_season_team()}: Get Season Statistics by Team}{.}
-\item{\code{cfbd_stats_season_advanced()}: Get Season Advanced Statistics by Team}{.}
-\item{\code{cfbd_stats_game_advanced()}: Get Game Advanced Stats}{.}
-\item{\code{cfbd_stats_season_player()}: Get Season Statistics by Player}{.}
+\item{\code{cfbd_stats_categories()}:}{College Football Mapping for Stats Categories.}
+\item{\code{cfbd_stats_season_team()}:}{Get Season Statistics by Team.}
+\item{\code{cfbd_stats_season_advanced()}:}{Get Season Advanced Statistics by Team.}
+\item{\code{cfbd_stats_game_advanced()}:}{Get Game Advanced Stats.}
+\item{\code{cfbd_stats_season_player()}:}{Get Season Statistics by Player.}
 }
 
 \code{\link[=cfbd_stats_categories]{cfbd_stats_categories()}} This function identifies all Stats Categories identified in the regular stats endpoint.

--- a/man/cfbd_teams.Rd
+++ b/man/cfbd_teams.Rd
@@ -143,6 +143,7 @@ If year is left blank while only_fbs is TRUE, then will return values for most c
 \item{\code{home_latitude}: numeric.}{Hometown latitude.}
 \item{\code{home_longitude}: number.}{Hometown longitude.}
 \item{\code{home_county_fips}: integer.}{Hometown FIPS code.}
+\item{\code{headshot_url}: character}{Player ESPN headshot url.}
 }
 
 \code{\link[=cfbd_team_talent]{cfbd_team_talent()}} - A data frame with 3 variables:
@@ -154,11 +155,11 @@ If year is left blank while only_fbs is TRUE, then will return values for most c
 }
 \description{
 \describe{
-\item{\code{cfbd_team_info()}: Team Info Lookup}{.}
-\item{\code{cfbd_team_matchup_records()}: Get matchup history records between two teams.}{.}
-\item{\code{cfbd_team_matchup()}: Get matchup history between two teams.}{.}
-\item{\code{cfbd_team_roster()}: Get a team's full roster by year.}{.}
-\item{\code{cfbd_team_talent()}: Get composite team talent rankings for all teams in a given year}{.}
+\item{\code{cfbd_team_info()}:}{Team Info Lookup.}
+\item{\code{cfbd_team_matchup_records()}:}{Get matchup history records between two teams.}
+\item{\code{cfbd_team_matchup()}:}{Get matchup history between two teams.}
+\item{\code{cfbd_team_roster()}:}{Get a team's full roster by year.}
+\item{\code{cfbd_team_talent()}:}{Get composite team talent rankings for all teams in a given year.}
 }
 \subsection{Team Info Lookup}{
 

--- a/tests/testthat/test-cfbd_game_box_advanced.R
+++ b/tests/testthat/test-cfbd_game_box_advanced.R
@@ -2,8 +2,24 @@ context("CFB Game Box Advanced")
 
 
 
-cols <- c("stat", "team1", "team2")
-cols <- c("team", "ppa_plays", "ppa_overall_total", "ppa_overall_quarter1", "ppa_overall_quarter2", "ppa_overall_quarter3", "ppa_overall_quarter4", "ppa_passing_total", "ppa_passing_quarter1", "ppa_passing_quarter2", "ppa_passing_quarter3", "ppa_passing_quarter4", "ppa_rushing_total", "ppa_rushing_quarter1", "ppa_rushing_quarter2", "ppa_rushing_quarter3", "ppa_rushing_quarter4", "cumulative_ppa_plays", "cumulative_ppa_overall_total", "cumulative_ppa_overall_quarter1", "cumulative_ppa_overall_quarter2", "cumulative_ppa_overall_quarter3", "cumulative_ppa_overall_quarter4", "cumulative_ppa_passing_total", "cumulative_ppa_passing_quarter1", "cumulative_ppa_passing_quarter2", "cumulative_ppa_passing_quarter3", "cumulative_ppa_passing_quarter4", "cumulative_ppa_rushing_total", "cumulative_ppa_rushing_quarter1", "cumulative_ppa_rushing_quarter2", "cumulative_ppa_rushing_quarter3", "cumulative_ppa_rushing_quarter4", "success_rates_overall_total", "success_rates_overall_quarter1", "success_rates_overall_quarter2", "success_rates_overall_quarter3", "success_rates_overall_quarter4", "success_rates_standard_downs_total", "success_rates_standard_downs_quarter1", "success_rates_standard_downs_quarter2", "success_rates_standard_downs_quarter3", "success_rates_standard_downs_quarter4", "success_rates_passing_downs_total", "success_rates_passing_downs_quarter1", "success_rates_passing_downs_quarter2", "success_rates_passing_downs_quarter3", "success_rates_passing_downs_quarter4", "explosiveness_overall_total", "explosiveness_overall_quarter1", "explosiveness_overall_quarter2", "explosiveness_overall_quarter3", "explosiveness_overall_quarter4", "rushing_power_success", "rushing_stuff_rate", "rushing_line_yds", "rushing_line_yd_avg", "rushing_second_lvl_yds", "rushing_second_lvl_yd_avg", "rushing_open_field_yds", "rushing_open_field_yd_avg", "havoc_total", "havoc_front_seven", "havoc_db", "scoring_opps_opportunities", "scoring_opps_points", "scoring_opps_pts_per_opp", "field_pos_avg_start", "field_pos_avg_starting_predicted_pts")
+cols1 <- c("stat", "team1", "team2")
+cols2 <- c(
+  "team", "ppa_plays", 
+  "ppa_overall_total", "ppa_overall_quarter1", "ppa_overall_quarter2", "ppa_overall_quarter3", "ppa_overall_quarter4", 
+  "ppa_passing_total", "ppa_passing_quarter1", "ppa_passing_quarter2", "ppa_passing_quarter3", "ppa_passing_quarter4",
+  "ppa_rushing_total", "ppa_rushing_quarter1", "ppa_rushing_quarter2", "ppa_rushing_quarter3", "ppa_rushing_quarter4", 
+  "cumulative_ppa_plays", "cumulative_ppa_overall_total", "cumulative_ppa_overall_quarter1", "cumulative_ppa_overall_quarter2", 
+  "cumulative_ppa_overall_quarter3", "cumulative_ppa_overall_quarter4",
+  "cumulative_ppa_passing_total", "cumulative_ppa_passing_quarter1", "cumulative_ppa_passing_quarter2", 
+  "cumulative_ppa_passing_quarter3", "cumulative_ppa_passing_quarter4", "cumulative_ppa_rushing_total", 
+  "cumulative_ppa_rushing_quarter1", "cumulative_ppa_rushing_quarter2", "cumulative_ppa_rushing_quarter3", 
+  "cumulative_ppa_rushing_quarter4", "success_rates_overall_total", 
+  "success_rates_overall_quarter1", "success_rates_overall_quarter2", "success_rates_overall_quarter3", "success_rates_overall_quarter4", 
+  "success_rates_standard_downs_total", "success_rates_standard_downs_quarter1", "success_rates_standard_downs_quarter2", "success_rates_standard_downs_quarter3", "success_rates_standard_downs_quarter4",
+  "success_rates_passing_downs_total", "success_rates_passing_downs_quarter1", "success_rates_passing_downs_quarter2", "success_rates_passing_downs_quarter3", "success_rates_passing_downs_quarter4", 
+  "explosiveness_overall_total", "explosiveness_overall_quarter1", "explosiveness_overall_quarter2", "explosiveness_overall_quarter3", "explosiveness_overall_quarter4", 
+  "rushing_power_success", "rushing_stuff_rate", "rushing_line_yds", "rushing_line_yds_avg", "rushing_second_lvl_yds", "rushing_second_lvl_yds_avg",
+  "rushing_open_field_yds", "rushing_open_field_yds_avg", "havoc_total", "havoc_front_seven", "havoc_db", "scoring_opps_opportunities", "scoring_opps_points", "scoring_opps_pts_per_opp", "field_pos_avg_start", "field_pos_avg_starting_predicted_pts")
 test_that("CFB Game Box Advanced", {
   skip_on_cran()
   x <- cfbd_game_box_advanced(game_id = 401012356)
@@ -11,8 +27,8 @@ test_that("CFB Game Box Advanced", {
   y <- cfbd_game_box_advanced(game_id = 401110720)
   expect_equal(nrow(x), 2)
   expect_equal(nrow(y), 2)
-  expect_equal(colnames(x), cols)
-  expect_equal(colnames(y), cols)
+  expect_equal(colnames(x), cols2)
+  expect_equal(colnames(y), cols2)
   expect_s3_class(x, "data.frame")
   expect_s3_class(y, "data.frame")
 })

--- a/tests/testthat/test-cfbd_team_roster.R
+++ b/tests/testthat/test-cfbd_team_roster.R
@@ -3,7 +3,7 @@ context("CFB Team Roster")
 cols <- c(
   "athlete_id", "first_name", "last_name", "team", "weight", "height",
   "jersey", "year", "position", "home_city", "home_state",
-  "home_country","home_latitude","home_longitude", "home_county_fips"
+  "home_country","home_latitude","home_longitude", "home_county_fips",'headshot_url'
 )
 
 test_that("CFB Team Roster", {

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -82,7 +82,7 @@ You can save the key for consistent usage by adding `CFBD_API_KEY=XXXX-YOUR-API-
 
 Run [**`usethis::edit_r_environ()`**](https://usethis.r-lib.org/reference/edit.html) and THEN paste the following in the new script that pops up (with**out** quotations)
 
-``` {.r}
+``` {r}
 CFBD_API_KEY = XXXX-YOUR-API-KEY-HERE-XXXXX
 ```
 

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -32,6 +32,26 @@ Hey folks,
 
 Welcome to the football analytics community! I'm Saiem Gilani, one of the [authors](https://saiemgilani.github.io/cfbfastR/authors.html "Authors and contributors to cfbfastR") of [`cfbfastR`](https://twitter.com/cfbfastR "Follow @cfbfastR on Twitter! Tag us in your tweets using cfbfastR and we'll share it!"), and I hope to give the community a high-quality resource for accessing college football data for statistical analysis, football research, and more. I am excited to show you some of what you can do with this edition of the package.
 
+### **Installing R and RStudio**
+  1. Head to [https://cran.r-project.org](https://cran.r-project.org "The Comprehensive R Archive Network")
+  2. Select the appropriate link for your operating system (Windows, Mac OS X, or Linux)
+    - **Windows** - Select base and download the most recent version
+    - **Mac OS X** - Select Latest Release, but check to make sure your OS is the correct version. Look  through Binaries for Legacy OS X Systems if you are on an older release
+    - **Linux** - Select the appropriate distro and follow the installation instructions
+  3. Head to [RStudio.com](https://www.rstudio.com/products/rstudio/download/#download "Download the appropriate version of RStudio (Free) for your operating system to use with R")
+  4. Follow the associated download and installation instructions for RStudio.
+  5. Start peering over the [RStudio IDE Cheatsheet]("https://www.rstudio.com/wp-content/uploads/2016/01/rstudio-IDE-cheatsheet.pdf"). *An IDE is an integrated development environment.*
+  
+#### **Load and install the necessary packages**
+
+```{r load_cfbfastR_tidy}
+if (!requireNamespace('pacman', quietly = TRUE)){
+  install.packages('pacman')
+}
+pacman::p_load_current_gh("saiemgilani/cfbfastR")
+pacman::p_load(tidyverse, zoo, ggimage, gt)
+```
+
 ### **The Data**
 There are generally speaking **three** college football data sources accessed from this package:
 
@@ -52,7 +72,7 @@ However, there is only one data *provider* involved for most game data, ESPN's d
 As of `cfbfastR` version `r remote_version`, the package exports `r nrow(exported)` functions. The bulk (\~`r cfbd_funcs`) of the functions within the package serve as the unofficial R API client for the [College Football Data API](https://collegefootballdata.com).
 
 #### **CFB Data now requires an API key (it's free)**
--   Starting on April 1, 2021, the College Football Data API requires [key authentication](https://collegefootballdata.com/key), but the **key is free to acquire and use**.
+-   Since April 1, 2021, the College Football Data API requires [key authentication](https://collegefootballdata.com/key), but the **key is free to acquire and use**.
 
 -   [Follow the instructions](https://collegefootballdata.com/key) and wait for your API key to be delivered to the e-mail account associated with your key.
 
@@ -75,14 +95,6 @@ Sys.setenv(CFBD_API_KEY = "XXXX-YOUR-API-KEY-HERE-XXXXX")
 
 If you have ever worked with the now archived [`cfbscrapR`](https://github.com/saiemgilani/cfbscrapR) package, most of the functions in ```cfbfastR``` should be fairly familiar with some slight changes.
 
-#### **Load and install the necessary packages**
-```{r load_cfbfastR_tidy}
-if (!requireNamespace('pacman', quietly = TRUE)){
-  install.packages('pacman')
-}
-pacman::p_load_current_gh("saiemgilani/cfbfastR")
-pacman::p_load(tidyverse, zoo, ggimage, gt)
-```
 
 We are going to load in data for seasons 2014-2020, it'll take between 45-90 seconds to run.
 ```{r load_2014_2020, warning = FALSE}


### PR DESCRIPTION
* Added headshot_url to outputs of [```cfbd_team_rosters```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_teams.html)

* Renamed returns in [```cfbd_game_advanced()```](https://saiemgilani.github.io/cfbfastR/reference/cfbd_games.html):
  - `rushing_line_yd_avg` to plural `rushing_line_yds_avg`
  - `rushing_second_lvl_yd_avg` to plural `rushing_second_lvl_yds_avg`
  - `rushing_open_field_yd_avg` to plural `rushing_open_field_yds_avg`

* Completed documentation for all returns except ```cfbd_pbp_data()```

* Continued work on intro vignette

* closes #8 

