### PR TITLE
add filters to not run EPA on 5th down

### DIFF
--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -42,7 +42,7 @@ create_epa <- function(play_df,
 
   clean_pbp <- play_df %>%
     dplyr::mutate(down = as.numeric(.data$down)) %>%
-    dplyr::filter(.data$down > 0, .data$down < 5) %>%
+    dplyr::filter(.data$down > 0) %>%
     dplyr::filter(.data$period <= 4)
 
   ## 1) pred_df and pred_df_after selection and prediction ----
@@ -63,7 +63,7 @@ create_epa <- function(play_df,
       .data$Goal_To_Go,
       .data$pos_score_diff_start
     ) %>%
-    dplyr::filter(.data$down > 0, .data$down < 5) %>%
+    dplyr::filter(.data$down > 0) %>%
     dplyr::mutate(down = as.factor(.data$down))
 
   # get after play expected points model variables
@@ -84,7 +84,7 @@ create_epa <- function(play_df,
       .data$new_pos_score_diff_start
     ) %>%
     dplyr::mutate(new_down = as.numeric(.data$new_down)) %>%
-    dplyr::filter(.data$new_down > 0, .data$new_down < 5) %>%
+    dplyr::filter(.data$new_down > 0) %>%
     dplyr::mutate(new_down = as.factor(.data$new_down))
   # rename column names for post play variables to expected points model variables
   colnames(pred_df_after)[6:13] <- gsub("new_", "", colnames(pred_df_after)[6:13])

--- a/R/create_epa.R
+++ b/R/create_epa.R
@@ -1,6 +1,6 @@
 #' @name create_epa
 #' @aliases create_epa epa_fg_probs
-#' @title 
+#' @title
 #' **Create EPA**
 #' @description Adds Expected Points calculations to Play-by-Play data.frame
 #'
@@ -38,11 +38,11 @@ create_epa <- function(play_df,
   ## 5) Calculate ep_before for kickoffs as if the pre-play assumption is a touchback
   ## 6) Prep variables for WPA
   ##
-  
-  
+
+
   clean_pbp <- play_df %>%
     dplyr::mutate(down = as.numeric(.data$down)) %>%
-    dplyr::filter(.data$down > 0) %>%
+    dplyr::filter(.data$down > 0, .data$down < 5) %>%
     dplyr::filter(.data$period <= 4)
 
   ## 1) pred_df and pred_df_after selection and prediction ----
@@ -63,7 +63,7 @@ create_epa <- function(play_df,
       .data$Goal_To_Go,
       .data$pos_score_diff_start
     ) %>%
-    dplyr::filter(.data$down > 0) %>%
+    dplyr::filter(.data$down > 0, .data$down < 5) %>%
     dplyr::mutate(down = as.factor(.data$down))
 
   # get after play expected points model variables
@@ -84,7 +84,7 @@ create_epa <- function(play_df,
       .data$new_pos_score_diff_start
     ) %>%
     dplyr::mutate(new_down = as.numeric(.data$new_down)) %>%
-    dplyr::filter(.data$new_down > 0) %>%
+    dplyr::filter(.data$new_down > 0, .data$new_down < 5) %>%
     dplyr::mutate(new_down = as.factor(.data$new_down))
   # rename column names for post play variables to expected points model variables
   colnames(pred_df_after)[6:13] <- gsub("new_", "", colnames(pred_df_after)[6:13])

--- a/R/helper_pbp_penalty_detection.R
+++ b/R/helper_pbp_penalty_detection.R
@@ -155,8 +155,8 @@ penalty_detection <- function(raw_df) {
       ),
       down = ifelse(.data$down == 5 & stringr::str_detect(.data$play_type, "Penalty"), 1, .data$down),
       half = ifelse(.data$period <= 2, 1, 2),
-      # Timeouts on kickoffs
-      down = ifelse(.data$down == 5 & stringr::str_detect(.data$play_type, "Timeout"), 1, .data$down),
+      # Timeouts on kickoffs actually breaks everything
+      down = ifelse(.data$down == 5 & stringr::str_detect(.data$play_type, "Timeout"), 0, .data$down),
     ) %>%
     dplyr::filter(!(.data$game_id == "302610012" & .data$down == 5 & .data$play_type == "Rush"))
   return(raw_df)

--- a/R/helper_pbp_penalty_detection.R
+++ b/R/helper_pbp_penalty_detection.R
@@ -154,7 +154,9 @@ penalty_detection <- function(raw_df) {
         "Penalty (Kickoff)", .data$play_type
       ),
       down = ifelse(.data$down == 5 & stringr::str_detect(.data$play_type, "Penalty"), 1, .data$down),
-      half = ifelse(.data$period <= 2, 1, 2)
+      half = ifelse(.data$period <= 2, 1, 2),
+      # Timeouts on kickoffs
+      down = ifelse(.data$down == 5 & stringr::str_detect(.data$play_type, "Timeout"), 1, .data$down),
     ) %>%
     dplyr::filter(!(.data$game_id == "302610012" & .data$down == 5 & .data$play_type == "Rush"))
   return(raw_df)


### PR DESCRIPTION
 (timeouts on xp or 2pt play after 4th down TD). This may be cheating, I'm not sure but I saw in the epa prep there was a filter for down>0 so figured the same logic would apply to just add down < 5. It was able to run on the Florida State game and I can't imagine it would break anything else (which means it probably did)