### PR TITLE
remove `qs` due to deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cfbfastR
 Title: Access College Football Play by Play Data
-Version: 2.2.0
+Version: 2.2.1
 Authors@R: c(
     person("Saiem", "Gilani", , "saiem.gilani@gmail.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-7194-9067")),
@@ -60,7 +60,6 @@ Suggests:
     ggplot2,
     ggrepel,
     patrick,
-    qs (>= 0.25.1),
     rmarkdown,
     RSQLite,
     stats,

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,9 +72,6 @@ read_raw_rds <- function(raw) {
   return(ret)
 }
 
-# read qs files form an url
-qs_from_url <- function(url) qs::qdeserialize(curl::curl_fetch_memory(url)$content)
-
 
 # The function `message_completed` to create the green "...completed" message
 # only exists to hide the option `in_builder` in dots


### PR DESCRIPTION
More details on deprecation: https://github.com/qsbase/qs/issues/103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2.2.1
  * Removed qs from optional dependencies to streamline package installation and reduce unnecessary overhead

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->