### PR TITLE
fix(pbp): keep returner name columns so every role ships id and name

### DIFF
--- a/R/pbp_output_schema.R
+++ b/R/pbp_output_schema.R
@@ -149,14 +149,22 @@
 )
 
 #' Player-name alias columns dropped on output (legacy quirks)
+#'
+#' `punt_return_player` / `kickoff_return_player` are the raw regex
+#' intermediates and `rush_player_name` duplicates `rusher_player_name`, so all
+#' three are genuine aliases.
+#'
+#' The two `*_return_player_name` columns were dropped here historically but are
+#' NOT aliases: the released pbp ships `punt_return_player_id` /
+#' `kickoff_return_player_id`, so withholding the name twin made returners the
+#' only credited role in the dataset identifiable by id alone. They are retained
+#' as of this change so every role ships id *and* name.
 #' @keywords internal
 #' @noRd
 .pbp_drop_player_aliases <- c(
   "punt_return_player",
   "kickoff_return_player",
-  "rush_player_name",
-  "punt_return_player_name",
-  "kickoff_return_player_name"
+  "rush_player_name"
 )
 
 #' Lag/lead intermediates produced for the pipeline's internal use

--- a/tests/testthat/test-pbp_output_schema.R
+++ b/tests/testthat/test-pbp_output_schema.R
@@ -42,10 +42,17 @@ test_that(".pbp_apply_output_schema() drops the documented player-name aliases",
     stringsAsFactors              = FALSE
   )
   out <- cfbfastR:::.pbp_apply_output_schema(df)
+  # Genuine aliases: the raw regex intermediates and the rusher_player_name
+  # duplicate.
   drop_set <- c("punt_return_player", "kickoff_return_player",
-                "rush_player_name", "punt_return_player_name",
-                "kickoff_return_player_name")
+                "rush_player_name")
   expect_false(any(drop_set %in% colnames(out)))
+
+  # The returner NAME columns are retained: the released pbp ships
+  # punt_return_player_id / kickoff_return_player_id, so dropping the name twin
+  # made a returner the only credited role identifiable by id alone.
+  expect_true(all(c("punt_return_player_name",
+                    "kickoff_return_player_name") %in% colnames(out)))
 })
 
 test_that(".pbp_apply_output_schema(output = 'default') drops the tier-1 sets", {


### PR DESCRIPTION
## Problem

The released `espn_cfb_pbp` ships `punt_return_player_id` and `kickoff_return_player_id`, but `.pbp_drop_player_aliases` dropped their name twins — making **a returner the only credited role in the dataset identifiable by id alone**. Every other role (rusher, passer, receiver, sacker, punter, kicker, interceptor, fumble trio) ships both id and name.

Surfaced by a full-history participant census over 2004–2025 (3,145,840 plays), which inventoried all 19 credit-carrying columns and flagged these two as the lone id-without-name case.

## Change

Retain `punt_return_player_name` / `kickoff_return_player_name`. The genuine aliases stay dropped: the raw `*_return_player` regex intermediates and `rush_player_name` (a duplicate of `rusher_player_name`).

Published pbp width 371 → 373.

## Coordination

The cfb-data polars port mirrors this change (sportsdataverse/cfbfastR-cfb-data PR). **Both must land together** — the R↔Python parity gate compares the Python build against the released R oracle and trips on any column-set divergence.

## Testing

`test-pbp_output_schema.R` updated: the drop assertion now covers only the three genuine aliases, plus a positive assertion that the two returner name columns survive.

## Summary by Sourcery

Retain returner name columns in play-by-play output so returner roles include both id and name, and adjust schema tests accordingly.

Bug Fixes:
- Ensure punt and kickoff returner name columns are no longer dropped, restoring id-and-name parity with other credited roles.

Tests:
- Update pbp output schema tests to only assert dropping genuine alias columns and to confirm returner name columns are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Returner name information is now retained in play-by-play data for punt and kickoff returns.
  * Returner roles now include both player IDs and names.
  * Unneeded raw and duplicate player aliases continue to be removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->